### PR TITLE
Performance improvements on queries

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,8 @@ app.layout = html.Div([
     sidebar,
     content,
     dummy_div,
-    dcc.Store(id='stored-data')
+    dcc.Store(id='stored-data'),
+    dcc.Store(id='stored-data-func'),
 ])
 
 @app.callback(
@@ -100,11 +101,21 @@ def fetch_data_once(data):
     if data is None:
         df = queries.get_expenditure_w_porverty_by_country_year()
         countries = sorted(df['country_name'].unique())
-        func_econ_df = queries.get_expenditure_by_country_func_econ_year()
-        func_df = queries.get_expenditure_by_country_func_year()
         return ({
             'countries': countries,
             'expenditure_w_poverty_by_country_year': df.to_dict('records'),
+        })
+    return dash.no_update
+
+@app.callback(
+    Output('stored-data-func', 'data'),
+    Input('stored-data-func', 'data')
+)
+def fetch_func_data_once(data):
+    if data is None:
+        func_df = queries.get_expenditure_by_country_func_year()
+        func_econ_df = queries.get_expenditure_by_country_func_econ_year()
+        return ({
             'expenditure_by_country_func_econ_year': func_econ_df.to_dict('records'),
             'expenditure_by_country_func_year': func_df.to_dict('records'),
         })

--- a/app.py
+++ b/app.py
@@ -80,6 +80,8 @@ app.layout = html.Div([
     dummy_div,
     dcc.Store(id='stored-data'),
     dcc.Store(id='stored-data-func'),
+    dcc.Store(id='stored-data-education-total'),
+    dcc.Store(id='stored-data-education-outcome')
 ])
 
 @app.callback(

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from dash.long_callback import DiskcacheLongCallbackManager
 import queries
 
 import diskcache
-
 cache = diskcache.Cache("./cache")
 long_callback_manager = DiskcacheLongCallbackManager(cache)
 
@@ -35,20 +34,19 @@ CONTENT_STYLE = {
     "padding": "2rem 1rem",
 }
 
-
 def get_relative_path(page_name):
-    return dash.page_registry[f"pages.{page_name}"]["relative_path"]
+    return dash.page_registry[f'pages.{page_name}']['relative_path']
 
 
 sidebar = html.Div(
     [
-        dbc.Row(
-            [
-                html.Img(
-                    src=app.get_asset_url("rpf_logo.png"), style={"height": "100"}
-                ),
-            ]
-        ),
+        dbc.Row([
+            html.Img(
+                src=app.get_asset_url('rpf_logo.png'),
+                style={'height': '100'}
+            ),
+        ]),
+
         html.Hr(),
         dbc.Select(
             id="country-select",
@@ -57,12 +55,10 @@ sidebar = html.Div(
         html.Hr(),
         dbc.Nav(
             [
-                dbc.NavLink("Overview", href=get_relative_path("home"), active="exact"),
-                dbc.NavLink(
-                    "Education", href=get_relative_path("education"), active="exact"
-                ),
-                dbc.NavLink("Health", href=get_relative_path("health"), active="exact"),
-                dbc.NavLink("About", href=get_relative_path("about"), active="exact"),
+                dbc.NavLink("Overview", href=get_relative_path('home'), active="exact"),
+                dbc.NavLink("Education", href=get_relative_path('education'), active="exact"),
+                dbc.NavLink("Health", href=get_relative_path('health'), active="exact"),
+                dbc.NavLink("About", href=get_relative_path('about'), active="exact"),
             ],
             vertical=True,
             pills=True,
@@ -71,59 +67,64 @@ sidebar = html.Div(
     style=SIDEBAR_STYLE,
 )
 
-content = html.Div(dash.page_container, id="page-content", style=CONTENT_STYLE)
+content = html.Div(dash.page_container,
+    id="page-content", style=CONTENT_STYLE
+)
 
 dummy_div = html.Div(id="div-for-redirect")
 
-app.layout = html.Div(
-    [
-        dcc.Location(id="url", refresh=False),
-        sidebar,
-        content,
-        dummy_div,
-        dcc.Store(id="stored-data"),
-        dcc.Store(id="stored-data-func"),
-    ]
+app.layout = html.Div([
+    dcc.Location(id='url', refresh=False),
+    sidebar,
+    content,
+    dummy_div,
+    dcc.Store(id='stored-data'),
+    dcc.Store(id='stored-data-func'),
+])
+
+@app.callback(
+    Output('div-for-redirect', 'children'),
+    Input('url', 'pathname')
 )
-
-
-@app.callback(Output("div-for-redirect", "children"), Input("url", "pathname"))
 def redirect_default(url_pathname):
-    known_paths = list(p["relative_path"] for p in dash.page_registry.values())
+    known_paths = list(p['relative_path'] for p in dash.page_registry.values())
     if url_pathname not in known_paths:
-        return dcc.Location(pathname=get_relative_path("home"), id="redirect-me")
+        return dcc.Location(pathname=get_relative_path('home'), id="redirect-me")
     else:
         return ""
 
-
-@app.callback(Output("stored-data", "data"), Input("stored-data", "data"))
+@app.callback(
+    Output('stored-data', 'data'),
+    Input('stored-data', 'data')
+)
 def fetch_data_once(data):
     if data is None:
         df = queries.get_expenditure_w_porverty_by_country_year()
-        countries = sorted(df["country_name"].unique())
-        return {
-            "countries": countries,
-            "expenditure_w_poverty_by_country_year": df.to_dict("records"),
-        }
+        countries = sorted(df['country_name'].unique())
+        return ({
+            'countries': countries,
+            'expenditure_w_poverty_by_country_year': df.to_dict('records'),
+        })
     return dash.no_update
 
-
-@app.callback(Output("stored-data-func", "data"), Input("stored-data-func", "data"))
+@app.callback(
+    Output('stored-data-func', 'data'),
+    Input('stored-data-func', 'data')
+)
 def fetch_func_data_once(data):
     if data is None:
         func_df = queries.get_expenditure_by_country_func_year()
         func_econ_df = queries.get_expenditure_by_country_func_econ_year()
-        return {
-            "expenditure_by_country_func_econ_year": func_econ_df.to_dict("records"),
-            "expenditure_by_country_func_year": func_df.to_dict("records"),
-        }
+        return ({
+            'expenditure_by_country_func_econ_year': func_econ_df.to_dict('records'),
+            'expenditure_by_country_func_year': func_df.to_dict('records'),
+        })
     return dash.no_update
 
-
 @app.callback(
-    Output("country-select", "options"),
-    Output("country-select", "value"),
-    Input("stored-data", "data"),
+    Output('country-select', 'options'),
+    Output('country-select', 'value'),
+    Input('stored-data', 'data')
 )
 def display_data(data):
     def get_country_select_options(countries):
@@ -132,14 +133,15 @@ def display_data(data):
         return options
 
     if data is not None:
-        countries = data["countries"]
+        countries = data['countries']
         return get_country_select_options(countries), countries[0]
     return ["No data available"], ""
 
 
+
 @app.long_callback(
-    Output("health-content", "children"),
-    Input("health-tabs", "active_tab"),
+    Output('health-content', 'children'),
+    Input('health-tabs', 'active_tab'),
     running=[
         (
             Output("health-spinner", "style"),
@@ -154,23 +156,19 @@ def display_data(data):
     ],
 )
 def render_health_content(tab):
-    if tab == "health-tab-time":
-        return html.Div(
-            [
-                "Time series viz"
-                # dcc.Graph(id='edu-plot', figure=make_edu_plot(gdp, country))
-            ]
-        )
-    elif tab == "health-tab-space":
-        return html.Div(
-            [
-                "Geospatial viz"
-                # dcc.Graph(id='health-plot', figure=make_health_plot(gdp, country))
-            ]
-        )
-
+    if tab == 'health-tab-time':
+        return html.Div([
+            'Time series viz'
+            # dcc.Graph(id='edu-plot', figure=make_edu_plot(gdp, country))
+        ])
+    elif tab == 'health-tab-space':
+        return html.Div([
+            'Geospatial viz'
+            # dcc.Graph(id='health-plot', figure=make_health_plot(gdp, country))
+        ])
 
 server = app.server
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app.run_server(debug=True)
+

--- a/app.py
+++ b/app.py
@@ -80,8 +80,6 @@ app.layout = html.Div([
     dummy_div,
     dcc.Store(id='stored-data'),
     dcc.Store(id='stored-data-func'),
-    dcc.Store(id='stored-data-education-total'),
-    dcc.Store(id='stored-data-education-outcome')
 ])
 
 @app.callback(

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from dash.long_callback import DiskcacheLongCallbackManager
 import queries
 
 import diskcache
+
 cache = diskcache.Cache("./cache")
 long_callback_manager = DiskcacheLongCallbackManager(cache)
 
@@ -34,19 +35,20 @@ CONTENT_STYLE = {
     "padding": "2rem 1rem",
 }
 
+
 def get_relative_path(page_name):
-    return dash.page_registry[f'pages.{page_name}']['relative_path']
+    return dash.page_registry[f"pages.{page_name}"]["relative_path"]
 
 
 sidebar = html.Div(
     [
-        dbc.Row([
-            html.Img(
-                src=app.get_asset_url('rpf_logo.png'),
-                style={'height': '100'}
-            ),
-        ]),
-
+        dbc.Row(
+            [
+                html.Img(
+                    src=app.get_asset_url("rpf_logo.png"), style={"height": "100"}
+                ),
+            ]
+        ),
         html.Hr(),
         dbc.Select(
             id="country-select",
@@ -55,10 +57,12 @@ sidebar = html.Div(
         html.Hr(),
         dbc.Nav(
             [
-                dbc.NavLink("Overview", href=get_relative_path('home'), active="exact"),
-                dbc.NavLink("Education", href=get_relative_path('education'), active="exact"),
-                dbc.NavLink("Health", href=get_relative_path('health'), active="exact"),
-                dbc.NavLink("About", href=get_relative_path('about'), active="exact"),
+                dbc.NavLink("Overview", href=get_relative_path("home"), active="exact"),
+                dbc.NavLink(
+                    "Education", href=get_relative_path("education"), active="exact"
+                ),
+                dbc.NavLink("Health", href=get_relative_path("health"), active="exact"),
+                dbc.NavLink("About", href=get_relative_path("about"), active="exact"),
             ],
             vertical=True,
             pills=True,
@@ -67,64 +71,59 @@ sidebar = html.Div(
     style=SIDEBAR_STYLE,
 )
 
-content = html.Div(dash.page_container,
-    id="page-content", style=CONTENT_STYLE
-)
+content = html.Div(dash.page_container, id="page-content", style=CONTENT_STYLE)
 
 dummy_div = html.Div(id="div-for-redirect")
 
-app.layout = html.Div([
-    dcc.Location(id='url', refresh=False),
-    sidebar,
-    content,
-    dummy_div,
-    dcc.Store(id='stored-data'),
-    dcc.Store(id='stored-data-func'),
-])
-
-@app.callback(
-    Output('div-for-redirect', 'children'),
-    Input('url', 'pathname')
+app.layout = html.Div(
+    [
+        dcc.Location(id="url", refresh=False),
+        sidebar,
+        content,
+        dummy_div,
+        dcc.Store(id="stored-data"),
+        dcc.Store(id="stored-data-func"),
+    ]
 )
+
+
+@app.callback(Output("div-for-redirect", "children"), Input("url", "pathname"))
 def redirect_default(url_pathname):
-    known_paths = list(p['relative_path'] for p in dash.page_registry.values())
+    known_paths = list(p["relative_path"] for p in dash.page_registry.values())
     if url_pathname not in known_paths:
-        return dcc.Location(pathname=get_relative_path('home'), id="redirect-me")
+        return dcc.Location(pathname=get_relative_path("home"), id="redirect-me")
     else:
         return ""
 
-@app.callback(
-    Output('stored-data', 'data'),
-    Input('stored-data', 'data')
-)
+
+@app.callback(Output("stored-data", "data"), Input("stored-data", "data"))
 def fetch_data_once(data):
     if data is None:
         df = queries.get_expenditure_w_porverty_by_country_year()
-        countries = sorted(df['country_name'].unique())
-        return ({
-            'countries': countries,
-            'expenditure_w_poverty_by_country_year': df.to_dict('records'),
-        })
+        countries = sorted(df["country_name"].unique())
+        return {
+            "countries": countries,
+            "expenditure_w_poverty_by_country_year": df.to_dict("records"),
+        }
     return dash.no_update
 
-@app.callback(
-    Output('stored-data-func', 'data'),
-    Input('stored-data-func', 'data')
-)
+
+@app.callback(Output("stored-data-func", "data"), Input("stored-data-func", "data"))
 def fetch_func_data_once(data):
     if data is None:
         func_df = queries.get_expenditure_by_country_func_year()
         func_econ_df = queries.get_expenditure_by_country_func_econ_year()
-        return ({
-            'expenditure_by_country_func_econ_year': func_econ_df.to_dict('records'),
-            'expenditure_by_country_func_year': func_df.to_dict('records'),
-        })
+        return {
+            "expenditure_by_country_func_econ_year": func_econ_df.to_dict("records"),
+            "expenditure_by_country_func_year": func_df.to_dict("records"),
+        }
     return dash.no_update
 
+
 @app.callback(
-    Output('country-select', 'options'),
-    Output('country-select', 'value'),
-    Input('stored-data', 'data')
+    Output("country-select", "options"),
+    Output("country-select", "value"),
+    Input("stored-data", "data"),
 )
 def display_data(data):
     def get_country_select_options(countries):
@@ -133,15 +132,14 @@ def display_data(data):
         return options
 
     if data is not None:
-        countries = data['countries']
+        countries = data["countries"]
         return get_country_select_options(countries), countries[0]
     return ["No data available"], ""
 
 
-
 @app.long_callback(
-    Output('health-content', 'children'),
-    Input('health-tabs', 'active_tab'),
+    Output("health-content", "children"),
+    Input("health-tabs", "active_tab"),
     running=[
         (
             Output("health-spinner", "style"),
@@ -156,19 +154,23 @@ def display_data(data):
     ],
 )
 def render_health_content(tab):
-    if tab == 'health-tab-time':
-        return html.Div([
-            'Time series viz'
-            # dcc.Graph(id='edu-plot', figure=make_edu_plot(gdp, country))
-        ])
-    elif tab == 'health-tab-space':
-        return html.Div([
-            'Geospatial viz'
-            # dcc.Graph(id='health-plot', figure=make_health_plot(gdp, country))
-        ])
+    if tab == "health-tab-time":
+        return html.Div(
+            [
+                "Time series viz"
+                # dcc.Graph(id='edu-plot', figure=make_edu_plot(gdp, country))
+            ]
+        )
+    elif tab == "health-tab-space":
+        return html.Div(
+            [
+                "Geospatial viz"
+                # dcc.Graph(id='health-plot', figure=make_health_plot(gdp, country))
+            ]
+        )
+
 
 server = app.server
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run_server(debug=True)
-

--- a/pages/education.py
+++ b/pages/education.py
@@ -19,8 +19,6 @@ layout = html.Div(children=[
             html.Div(id='education-content'),
         ]),
     ),
-    dcc.Store(id='stored-data-education-total'),
-    dcc.Store(id='stored-data-education-outcome')
 ])
 
 

--- a/pages/education.py
+++ b/pages/education.py
@@ -9,120 +9,139 @@ from utils import filter_country_sort_year
 
 dash.register_page(__name__)
 
-layout = html.Div(children=[
-    dbc.Card(
-        dbc.CardBody([
-            dbc.Tabs(id='education-tabs', active_tab='edu-tab-time', children=[
-                dbc.Tab(label='Over Time', tab_id='edu-tab-time'),
-                dbc.Tab(label='Across Space', tab_id='edu-tab-space'),
-            ], style={"marginBottom": "2rem"}),
-            html.Div(id='education-content'),
-        ]),
-    ),
-    dcc.Store(id='stored-data-education-total'),
-    dcc.Store(id='stored-data-education-outcome')
-])
+layout = html.Div(
+    children=[
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    dbc.Tabs(
+                        id="education-tabs",
+                        active_tab="edu-tab-time",
+                        children=[
+                            dbc.Tab(label="Over Time", tab_id="edu-tab-time"),
+                            dbc.Tab(label="Across Space", tab_id="edu-tab-space"),
+                        ],
+                        style={"marginBottom": "2rem"},
+                    ),
+                    html.Div(id="education-content"),
+                ]
+            ),
+        ),
+        dcc.Store(id="stored-data-education-total"),
+        dcc.Store(id="stored-data-education-outcome"),
+    ]
+)
 
 
 @callback(
-    Output('stored-data-education-total', 'data'),
-    Input('stored-data-education-total', 'data'),
-    Input('stored-data-func', 'data')
+    Output("stored-data-education-total", "data"),
+    Input("stored-data-education-total", "data"),
+    Input("stored-data-func", "data"),
 )
 def fetch_edu_total_data_once(edu_data, shared_data):
     if edu_data is None:
 
         # filter shared data down to education specific
-        exp_by_func = pd.DataFrame(shared_data['expenditure_by_country_func_year'])
-        pub_exp = exp_by_func[exp_by_func.func == 'Education']
+        exp_by_func = pd.DataFrame(shared_data["expenditure_by_country_func_year"])
+        pub_exp = exp_by_func[exp_by_func.func == "Education"]
 
-        return ({
-            "edu_public_expenditure": pub_exp.to_dict('records'),
-        })
+        return {
+            "edu_public_expenditure": pub_exp.to_dict("records"),
+        }
     return dash.no_update
 
 
 @callback(
-    Output('stored-data-education-outcome', 'data'),
-    Input('stored-data-education-outcome', 'data'),
-    Input('stored-data', 'data')
+    Output("stored-data-education-outcome", "data"),
+    Input("stored-data-education-outcome", "data"),
+    Input("stored-data", "data"),
 )
 def fetch_edu_outcome_data_once(edu_data, shared_data):
     if edu_data is None:
         learning_poverty = queries.get_learning_poverty_rate()
 
-        hd_index = queries.get_hd_index(shared_data['countries'])
+        hd_index = queries.get_hd_index(shared_data["countries"])
 
-        return ({
-            "learning_poverty": learning_poverty.to_dict('records'),
-            "hd_index": hd_index.to_dict('records'),
-        })
+        return {
+            "learning_poverty": learning_poverty.to_dict("records"),
+            "hd_index": hd_index.to_dict("records"),
+        }
     return dash.no_update
 
+
 @callback(
-    Output('education-content', 'children'),
-    Input('education-tabs', 'active_tab'),
+    Output("education-content", "children"),
+    Input("education-tabs", "active_tab"),
 )
 def render_education_content(tab):
-    if tab == 'edu-tab-time':
-        return html.Div([
-            dbc.Row(
-                dbc.Col(
-                    html.H3(
-                        children="Public Spending & Education Outcome",
-                    )
-                )
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.P(
-                        id="education-narrative",
-                        children="loading...",
-                    )
-                )
-            ),
-            dbc.Row(
-                [
-                    # How has total expenditure changed over time?
+    if tab == "edu-tab-time":
+        return html.Div(
+            [
+                dbc.Row(
                     dbc.Col(
-                        dcc.Graph(id="education-total", config={"displayModeBar": False},  ),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                        style={"marginBottom": "3rem"}
-
-                    ),
+                        html.H3(
+                            children="Public Spending & Education Outcome",
+                        )
+                    )
+                ),
+                dbc.Row(
                     dbc.Col(
-                        dcc.Graph(id="education-outcome", config={"displayModeBar": False}, ),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                    ),
-                ],
-            ),
-            dbc.Row(
-                [
-                # How has private expenditure vs public expenditure changed over time?
-                    ## The graph does not look right. Hiding for now
-                    # How has private expenditure vs public expenditure changed over time?
-                    # dbc.Col(
-                    #     dcc.Graph(id="education-public-private", config={"displayModeBar": False},  ),
-                    #     xs={"size": 12, "offset": 0},
-                    #     sm={"size": 12, "offset": 0},
-                    #     md={"size": 12, "offset": 0},
-                    #     lg={"size": 6, "offset": 0},
-                    #     style={"marginBottom": "3rem"}
-                    # ),
-                ],
-            ),
-        ])
-    elif tab == 'edu-tab-space':
-        return html.Div([
-            'Geospatial viz'
-            # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
-        ])
+                        html.P(
+                            id="education-narrative",
+                            children="loading...",
+                        )
+                    )
+                ),
+                dbc.Row(
+                    [
+                        # How has total expenditure changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="education-total",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                            style={"marginBottom": "3rem"},
+                        ),
+                        dbc.Col(
+                            dcc.Graph(
+                                id="education-outcome",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                        ),
+                    ],
+                ),
+                dbc.Row(
+                    [
+                        # How has private expenditure vs public expenditure changed over time?
+                        ## The graph does not look right. Hiding for now
+                        # How has private expenditure vs public expenditure changed over time?
+                        # dbc.Col(
+                        #     dcc.Graph(id="education-public-private", config={"displayModeBar": False},  ),
+                        #     xs={"size": 12, "offset": 0},
+                        #     sm={"size": 12, "offset": 0},
+                        #     md={"size": 12, "offset": 0},
+                        #     lg={"size": 6, "offset": 0},
+                        #     style={"marginBottom": "3rem"}
+                        # ),
+                    ],
+                ),
+            ]
+        )
+    elif tab == "edu-tab-space":
+        return html.Div(
+            [
+                "Geospatial viz"
+                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+            ]
+        )
 
 
 def total_edu_figure(df):
@@ -167,32 +186,35 @@ def total_edu_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
 
+
 def education_narrative(data, country):
-    spending = pd.DataFrame(data['edu_public_expenditure'])
+    spending = pd.DataFrame(data["edu_public_expenditure"])
     spending = filter_country_sort_year(spending, country)
 
     start_year = spending.year.min()
     end_year = spending.year.max()
     start_value = spending[spending.year == start_year].real_expenditure.values[0]
     end_value = spending[spending.year == end_year].real_expenditure.values[0]
-    spending_growth_rate = ((end_value - start_value)/ start_value) * 100
-    text = f'After accounting for inflation, real public spending in education has increased by {spending_growth_rate:.2f}% '\
-    f'between {start_year} and {end_year}. \n'\
-    f'Generally, while education outcomes related to access can be conceptually linked to the availability of public finance, results related to quality have a more complex chain of causality.'\
-    '\n'
+    spending_growth_rate = ((end_value - start_value) / start_value) * 100
+    text = (
+        f"After accounting for inflation, real public spending in education has increased by {spending_growth_rate:.2f}% "
+        f"between {start_year} and {end_year}. \n"
+        f"Generally, while education outcomes related to access can be conceptually linked to the availability of public finance, results related to quality have a more complex chain of causality."
+        "\n"
+    )
     return text
 
 
@@ -234,103 +256,117 @@ def private_public_fig(public, private):
         legend=dict(orientation="h", yanchor="bottom", y=1),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
 
+
 @callback(
-    Output('education-total', 'figure'),
-    Output('education-narrative', 'children'),
-    Input('stored-data-education-total', 'data'),
-    Input('country-select', 'value'),
+    Output("education-total", "figure"),
+    Output("education-narrative", "children"),
+    Input("stored-data-education-total", "data"),
+    Input("country-select", "value"),
 )
 def render_overview_total_figure(data, country):
     if data is None:
         return None
-    all_countries = pd.DataFrame(data['edu_public_expenditure'])
+    all_countries = pd.DataFrame(data["edu_public_expenditure"])
     df = filter_country_sort_year(all_countries, country)
     fig = total_edu_figure(df)
     return fig, education_narrative(data, country)
 
 
 @callback(
-    Output('education-public-private', 'figure'),
-    Input('stored-data-education-outcome', 'data'),
-    Input('country-select', 'value'),
+    Output("education-public-private", "figure"),
+    Input("stored-data-education-outcome", "data"),
+    Input("country-select", "value"),
 )
 def render_public_private_figure(data, country):
-    private = pd.DataFrame(data['edu_private_expenditure'])
+    private = pd.DataFrame(data["edu_private_expenditure"])
     private = private[private.country_name == country]
-    private['private_percentage'] = private['real_expenditure']/(private['real_expenditure'] + private['real_expenditure'])
-    private['public_percentage'] = private['real_expenditure']/(private['real_expenditure'] + private['real_expenditure'])
+    private["private_percentage"] = private["real_expenditure"] / (
+        private["real_expenditure"] + private["real_expenditure"]
+    )
+    private["public_percentage"] = private["real_expenditure"] / (
+        private["real_expenditure"] + private["real_expenditure"]
+    )
 
     fig = go.Figure()
-    fig.add_trace(go.Bar(
-        name="Private Expenditure",
-        y=private["year"].astype(str),
-        x=private.private_percentage,
-        orientation='h',
-        customdata=private.real_expenditure,
-        hovertemplate = '%{customdata:$}',
-        marker=dict(color='rgb(160, 209, 255)',)
-    ))
+    fig.add_trace(
+        go.Bar(
+            name="Private Expenditure",
+            y=private["year"].astype(str),
+            x=private.private_percentage,
+            orientation="h",
+            customdata=private.real_expenditure,
+            hovertemplate="%{customdata:$}",
+            marker=dict(
+                color="rgb(160, 209, 255)",
+            ),
+        )
+    )
 
-    fig.add_trace(go.Bar(
-        name="Public Expenditure",
-        y=private['year'].astype(str),
-        x=private.public_percentage,
-        orientation='h',
-        customdata=private.real_expenditure,
-        hovertemplate = '%{customdata:$}',
-        marker=dict(
-            color='rgb(17, 141, 255)',
-        ),
-    ))
+    fig.add_trace(
+        go.Bar(
+            name="Public Expenditure",
+            y=private["year"].astype(str),
+            x=private.public_percentage,
+            orientation="h",
+            customdata=private.real_expenditure,
+            hovertemplate="%{customdata:$}",
+            marker=dict(
+                color="rgb(17, 141, 255)",
+            ),
+        )
+    )
     fig.update_layout(
-        barmode='stack',
+        barmode="stack",
         plot_bgcolor="white",
         legend=dict(orientation="h", yanchor="bottom", y=1),
         title="What % was spent by the govt vs household?",
-        annotations=[dict(
-            xref='paper',
-            yref='paper',
-            x=-0.14,
-            y=-0.2,
-            text="Source: BOOST & CPI: World Bank",
-            showarrow=False,
-            font=dict(size=12)
-        )])
-    fig.update_xaxes(tickformat=',.0%')
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.14,
+                y=-0.2,
+                text="Source: BOOST & CPI: World Bank",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
+    )
+    fig.update_xaxes(tickformat=",.0%")
 
     return fig
 
+
 @callback(
-    Output('education-outcome', 'figure'),
-    Input('stored-data-education-outcome', 'data'),
-    Input('stored-data-education-total', 'data'),
-    Input('country-select', 'value'),
+    Output("education-outcome", "figure"),
+    Input("stored-data-education-outcome", "data"),
+    Input("stored-data-education-total", "data"),
+    Input("country-select", "value"),
 )
 def render_education_outcome(outcome_data, total_data, country):
     if not total_data or not outcome_data:
-        return 
-    indicator = pd.DataFrame(outcome_data['hd_index'])
+        return
+    indicator = pd.DataFrame(outcome_data["hd_index"])
     indicator = filter_country_sort_year(indicator, country)
     indicator = indicator[indicator.adm1_name == "Total"]
 
-    learning_poverty = pd.DataFrame(outcome_data['learning_poverty'])
+    learning_poverty = pd.DataFrame(outcome_data["learning_poverty"])
     learning_poverty = filter_country_sort_year(learning_poverty, country)
 
-
-    pub_exp = pd.DataFrame(total_data['edu_public_expenditure'])
+    pub_exp = pd.DataFrame(total_data["edu_public_expenditure"])
     pub_exp = filter_country_sort_year(pub_exp, country)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
@@ -341,10 +377,10 @@ def render_education_outcome(outcome_data, total_data, country):
             x=indicator.year,
             y=indicator.education_index,
             mode="lines+markers",
-            line=dict(color='MediumPurple', shape='spline', dash='dot'),
+            line=dict(color="MediumPurple", shape="spline", dash="dot"),
             connectgaps=True,
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
     fig.add_trace(
@@ -353,10 +389,10 @@ def render_education_outcome(outcome_data, total_data, country):
             x=learning_poverty.year,
             y=learning_poverty.learning_poverty_rate,
             mode="lines+markers",
-            line=dict(color='deeppink', shape='spline', dash='dot'),
+            line=dict(color="deeppink", shape="spline", dash="dot"),
             connectgaps=True,
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
     fig.add_trace(
@@ -368,35 +404,37 @@ def render_education_outcome(outcome_data, total_data, country):
             marker_color="darkblue",
             opacity=0.6,
         ),
-        secondary_y=False
+        secondary_y=False,
     )
 
     fig.update_layout(
         plot_bgcolor="white",
-            legend=dict(
-                orientation="h",
-                yanchor="bottom",
-                y=0.9,
-                xanchor="left",
-                x=0,
-                bgcolor='rgba(0,0,0,0)'
-            ),
-            title="How has education outcome changed?",
-            annotations=[
-                dict(
-                    xref='paper',
-                    yref='paper',
-                    x=-0.14,
-                    y=-0.25,
-                    text="Source: Education index measured by years of education: UNDP through GDL. <br>"\
-                         "BOOST, CPI, Learning Poverty: World Bank; Population: UN, Eurostat",
-                    showarrow=False,
-                    font=dict(size=12)
-                )]
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=0.9,
+            xanchor="left",
+            x=0,
+            bgcolor="rgba(0,0,0,0)",
+        ),
+        title="How has education outcome changed?",
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.14,
+                y=-0.25,
+                text="Source: Education index measured by years of education: UNDP through GDL. <br>"
+                "BOOST, CPI, Learning Poverty: World Bank; Population: UN, Eurostat",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
     )
 
-    fig.update_yaxes(range=[0, max(pub_exp.per_capita_real_expenditure)*1.2], secondary_y=False)
+    fig.update_yaxes(
+        range=[0, max(pub_exp.per_capita_real_expenditure) * 1.2], secondary_y=False
+    )
     fig.update_yaxes(range=[0, 1], secondary_y=True)
 
     return fig
-

--- a/pages/education.py
+++ b/pages/education.py
@@ -182,6 +182,7 @@ def total_edu_figure(df):
 def education_narrative(data, country):
     spending = pd.DataFrame(data['edu_public_expenditure'])
     spending = spending[spending.country_name == country]
+    spending.sort_values(['year'], inplace=True)
 
     start_year = spending.year.min()
     end_year = spending.year.max()
@@ -257,6 +258,7 @@ def render_overview_total_figure(data, country):
         return None
     all_countries = pd.DataFrame(data['edu_public_expenditure'])
     df = all_countries[all_countries.country_name == country]
+    df.sort_values(['year'], inplace=True)
     fig = total_edu_figure(df)
     return fig, education_narrative(data, country)
 
@@ -323,12 +325,15 @@ def render_education_outcome(outcome_data, total_data, country):
         return 
     indicator = pd.DataFrame(outcome_data['hd_index'])
     indicator = indicator[(indicator.country_name == country) & (indicator.adm1_name == "Total")]
+    indicator.sort_values(['year'],inplace=True)
 
     learning_poverty = pd.DataFrame(outcome_data['learning_poverty'])
     learning_poverty = learning_poverty[learning_poverty.country_name == country]
+    learning_poverty.sort_values(['year'], inplace=True)
 
     pub_exp = pd.DataFrame(total_data['edu_public_expenditure'])
     pub_exp = pub_exp[pub_exp.country_name == country]
+    pub_exp.sort_values(['year'], inplace=True)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 

--- a/pages/education.py
+++ b/pages/education.py
@@ -5,7 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import queries
-from utils import preprocess_df
+from utils import filter_country_sort_year
 
 dash.register_page(__name__)
 
@@ -180,7 +180,7 @@ def total_edu_figure(df):
 
 def education_narrative(data, country):
     spending = pd.DataFrame(data['edu_public_expenditure'])
-    spending = preprocess_df(spending, country)
+    spending = filter_country_sort_year(spending, country)
 
     start_year = spending.year.min()
     end_year = spending.year.max()
@@ -255,7 +255,7 @@ def render_overview_total_figure(data, country):
     if data is None:
         return None
     all_countries = pd.DataFrame(data['edu_public_expenditure'])
-    df = preprocess_df(all_countries, country)
+    df = filter_country_sort_year(all_countries, country)
     fig = total_edu_figure(df)
     return fig, education_narrative(data, country)
 
@@ -321,15 +321,15 @@ def render_education_outcome(outcome_data, total_data, country):
     if not total_data or not outcome_data:
         return 
     indicator = pd.DataFrame(outcome_data['hd_index'])
-    indicator = preprocess_df(indicator, country)
+    indicator = filter_country_sort_year(indicator, country)
     indicator = indicator[indicator.adm1_name == "Total"]
 
     learning_poverty = pd.DataFrame(outcome_data['learning_poverty'])
-    learning_poverty = preprocess_df(learning_poverty, country)
+    learning_poverty = filter_country_sort_year(learning_poverty, country)
 
 
     pub_exp = pd.DataFrame(total_data['edu_public_expenditure'])
-    pub_exp = preprocess_df(pub_exp, country)
+    pub_exp = filter_country_sort_year(pub_exp, country)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 

--- a/pages/education.py
+++ b/pages/education.py
@@ -19,6 +19,8 @@ layout = html.Div(children=[
             html.Div(id='education-content'),
         ]),
     ),
+    dcc.Store(id='stored-data-education-total'),
+    dcc.Store(id='stored-data-education-outcome')
 ])
 
 

--- a/pages/education.py
+++ b/pages/education.py
@@ -9,139 +9,120 @@ from utils import preprocess_df
 
 dash.register_page(__name__)
 
-layout = html.Div(
-    children=[
-        dbc.Card(
-            dbc.CardBody(
-                [
-                    dbc.Tabs(
-                        id="education-tabs",
-                        active_tab="edu-tab-time",
-                        children=[
-                            dbc.Tab(label="Over Time", tab_id="edu-tab-time"),
-                            dbc.Tab(label="Across Space", tab_id="edu-tab-space"),
-                        ],
-                        style={"marginBottom": "2rem"},
-                    ),
-                    html.Div(id="education-content"),
-                ]
-            ),
-        ),
-        dcc.Store(id="stored-data-education-total"),
-        dcc.Store(id="stored-data-education-outcome"),
-    ]
-)
+layout = html.Div(children=[
+    dbc.Card(
+        dbc.CardBody([
+            dbc.Tabs(id='education-tabs', active_tab='edu-tab-time', children=[
+                dbc.Tab(label='Over Time', tab_id='edu-tab-time'),
+                dbc.Tab(label='Across Space', tab_id='edu-tab-space'),
+            ], style={"marginBottom": "2rem"}),
+            html.Div(id='education-content'),
+        ]),
+    ),
+    dcc.Store(id='stored-data-education-total'),
+    dcc.Store(id='stored-data-education-outcome')
+])
 
 
 @callback(
-    Output("stored-data-education-total", "data"),
-    Input("stored-data-education-total", "data"),
-    Input("stored-data-func", "data"),
+    Output('stored-data-education-total', 'data'),
+    Input('stored-data-education-total', 'data'),
+    Input('stored-data-func', 'data')
 )
 def fetch_edu_total_data_once(edu_data, shared_data):
     if edu_data is None:
 
         # filter shared data down to education specific
-        exp_by_func = pd.DataFrame(shared_data["expenditure_by_country_func_year"])
-        pub_exp = exp_by_func[exp_by_func.func == "Education"]
+        exp_by_func = pd.DataFrame(shared_data['expenditure_by_country_func_year'])
+        pub_exp = exp_by_func[exp_by_func.func == 'Education']
 
-        return {
-            "edu_public_expenditure": pub_exp.to_dict("records"),
-        }
+        return ({
+            "edu_public_expenditure": pub_exp.to_dict('records'),
+        })
     return dash.no_update
 
 
 @callback(
-    Output("stored-data-education-outcome", "data"),
-    Input("stored-data-education-outcome", "data"),
-    Input("stored-data", "data"),
+    Output('stored-data-education-outcome', 'data'),
+    Input('stored-data-education-outcome', 'data'),
+    Input('stored-data', 'data')
 )
 def fetch_edu_outcome_data_once(edu_data, shared_data):
     if edu_data is None:
         learning_poverty = queries.get_learning_poverty_rate()
 
-        hd_index = queries.get_hd_index(shared_data["countries"])
+        hd_index = queries.get_hd_index(shared_data['countries'])
 
-        return {
-            "learning_poverty": learning_poverty.to_dict("records"),
-            "hd_index": hd_index.to_dict("records"),
-        }
+        return ({
+            "learning_poverty": learning_poverty.to_dict('records'),
+            "hd_index": hd_index.to_dict('records'),
+        })
     return dash.no_update
 
-
 @callback(
-    Output("education-content", "children"),
-    Input("education-tabs", "active_tab"),
+    Output('education-content', 'children'),
+    Input('education-tabs', 'active_tab'),
 )
 def render_education_content(tab):
-    if tab == "edu-tab-time":
-        return html.Div(
-            [
-                dbc.Row(
-                    dbc.Col(
-                        html.H3(
-                            children="Public Spending & Education Outcome",
-                        )
+    if tab == 'edu-tab-time':
+        return html.Div([
+            dbc.Row(
+                dbc.Col(
+                    html.H3(
+                        children="Public Spending & Education Outcome",
                     )
-                ),
-                dbc.Row(
-                    dbc.Col(
-                        html.P(
-                            id="education-narrative",
-                            children="loading...",
-                        )
+                )
+            ),
+            dbc.Row(
+                dbc.Col(
+                    html.P(
+                        id="education-narrative",
+                        children="loading...",
                     )
-                ),
-                dbc.Row(
-                    [
-                        # How has total expenditure changed over time?
-                        dbc.Col(
-                            dcc.Graph(
-                                id="education-total",
-                                config={"displayModeBar": False},
-                            ),
-                            xs={"size": 12, "offset": 0},
-                            sm={"size": 12, "offset": 0},
-                            md={"size": 12, "offset": 0},
-                            lg={"size": 6, "offset": 0},
-                            style={"marginBottom": "3rem"},
-                        ),
-                        dbc.Col(
-                            dcc.Graph(
-                                id="education-outcome",
-                                config={"displayModeBar": False},
-                            ),
-                            xs={"size": 12, "offset": 0},
-                            sm={"size": 12, "offset": 0},
-                            md={"size": 12, "offset": 0},
-                            lg={"size": 6, "offset": 0},
-                        ),
-                    ],
-                ),
-                dbc.Row(
-                    [
-                        # How has private expenditure vs public expenditure changed over time?
-                        ## The graph does not look right. Hiding for now
-                        # How has private expenditure vs public expenditure changed over time?
-                        # dbc.Col(
-                        #     dcc.Graph(id="education-public-private", config={"displayModeBar": False},  ),
-                        #     xs={"size": 12, "offset": 0},
-                        #     sm={"size": 12, "offset": 0},
-                        #     md={"size": 12, "offset": 0},
-                        #     lg={"size": 6, "offset": 0},
-                        #     style={"marginBottom": "3rem"}
-                        # ),
-                    ],
-                ),
-            ]
-        )
-    elif tab == "edu-tab-space":
-        return html.Div(
-            [
-                "Geospatial viz"
-                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
-            ]
-        )
+                )
+            ),
+            dbc.Row(
+                [
+                    # How has total expenditure changed over time?
+                    dbc.Col(
+                        dcc.Graph(id="education-total", config={"displayModeBar": False},  ),
+                        xs={"size": 12, "offset": 0},
+                        sm={"size": 12, "offset": 0},
+                        md={"size": 12, "offset": 0},
+                        lg={"size": 6, "offset": 0},
+                        style={"marginBottom": "3rem"}
+
+                    ),
+                    dbc.Col(
+                        dcc.Graph(id="education-outcome", config={"displayModeBar": False}, ),
+                        xs={"size": 12, "offset": 0},
+                        sm={"size": 12, "offset": 0},
+                        md={"size": 12, "offset": 0},
+                        lg={"size": 6, "offset": 0},
+                    ),
+                ],
+            ),
+            dbc.Row(
+                [
+                # How has private expenditure vs public expenditure changed over time?
+                    ## The graph does not look right. Hiding for now
+                    # How has private expenditure vs public expenditure changed over time?
+                    # dbc.Col(
+                    #     dcc.Graph(id="education-public-private", config={"displayModeBar": False},  ),
+                    #     xs={"size": 12, "offset": 0},
+                    #     sm={"size": 12, "offset": 0},
+                    #     md={"size": 12, "offset": 0},
+                    #     lg={"size": 6, "offset": 0},
+                    #     style={"marginBottom": "3rem"}
+                    # ),
+                ],
+            ),
+        ])
+    elif tab == 'edu-tab-space':
+        return html.Div([
+            'Geospatial viz'
+            # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+        ])
 
 
 def total_edu_figure(df):
@@ -186,35 +167,32 @@ def total_edu_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1),
         annotations=[
             dict(
-                xref="paper",
-                yref="paper",
+                xref='paper',
+                yref='paper',
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12),
+                font=dict(size=12)
             )
-        ],
+        ]
     )
 
     return fig
 
-
 def education_narrative(data, country):
-    spending = pd.DataFrame(data["edu_public_expenditure"])
+    spending = pd.DataFrame(data['edu_public_expenditure'])
     spending = preprocess_df(spending, country)
 
     start_year = spending.year.min()
     end_year = spending.year.max()
     start_value = spending[spending.year == start_year].real_expenditure.values[0]
     end_value = spending[spending.year == end_year].real_expenditure.values[0]
-    spending_growth_rate = ((end_value - start_value) / start_value) * 100
-    text = (
-        f"After accounting for inflation, real public spending in education has increased by {spending_growth_rate:.2f}% "
-        f"between {start_year} and {end_year}. \n"
-        f"Generally, while education outcomes related to access can be conceptually linked to the availability of public finance, results related to quality have a more complex chain of causality."
-        "\n"
-    )
+    spending_growth_rate = ((end_value - start_value)/ start_value) * 100
+    text = f'After accounting for inflation, real public spending in education has increased by {spending_growth_rate:.2f}% '\
+    f'between {start_year} and {end_year}. \n'\
+    f'Generally, while education outcomes related to access can be conceptually linked to the availability of public finance, results related to quality have a more complex chain of causality.'\
+    '\n'
     return text
 
 
@@ -256,117 +234,103 @@ def private_public_fig(public, private):
         legend=dict(orientation="h", yanchor="bottom", y=1),
         annotations=[
             dict(
-                xref="paper",
-                yref="paper",
+                xref='paper',
+                yref='paper',
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12),
+                font=dict(size=12)
             )
-        ],
+        ]
     )
 
     return fig
 
-
 @callback(
-    Output("education-total", "figure"),
-    Output("education-narrative", "children"),
-    Input("stored-data-education-total", "data"),
-    Input("country-select", "value"),
+    Output('education-total', 'figure'),
+    Output('education-narrative', 'children'),
+    Input('stored-data-education-total', 'data'),
+    Input('country-select', 'value'),
 )
 def render_overview_total_figure(data, country):
     if data is None:
         return None
-    all_countries = pd.DataFrame(data["edu_public_expenditure"])
+    all_countries = pd.DataFrame(data['edu_public_expenditure'])
     df = preprocess_df(all_countries, country)
     fig = total_edu_figure(df)
     return fig, education_narrative(data, country)
 
 
 @callback(
-    Output("education-public-private", "figure"),
-    Input("stored-data-education-outcome", "data"),
-    Input("country-select", "value"),
+    Output('education-public-private', 'figure'),
+    Input('stored-data-education-outcome', 'data'),
+    Input('country-select', 'value'),
 )
 def render_public_private_figure(data, country):
-    private = pd.DataFrame(data["edu_private_expenditure"])
+    private = pd.DataFrame(data['edu_private_expenditure'])
     private = private[private.country_name == country]
-    private["private_percentage"] = private["real_expenditure"] / (
-        private["real_expenditure"] + private["real_expenditure"]
-    )
-    private["public_percentage"] = private["real_expenditure"] / (
-        private["real_expenditure"] + private["real_expenditure"]
-    )
+    private['private_percentage'] = private['real_expenditure']/(private['real_expenditure'] + private['real_expenditure'])
+    private['public_percentage'] = private['real_expenditure']/(private['real_expenditure'] + private['real_expenditure'])
 
     fig = go.Figure()
-    fig.add_trace(
-        go.Bar(
-            name="Private Expenditure",
-            y=private["year"].astype(str),
-            x=private.private_percentage,
-            orientation="h",
-            customdata=private.real_expenditure,
-            hovertemplate="%{customdata:$}",
-            marker=dict(
-                color="rgb(160, 209, 255)",
-            ),
-        )
-    )
+    fig.add_trace(go.Bar(
+        name="Private Expenditure",
+        y=private["year"].astype(str),
+        x=private.private_percentage,
+        orientation='h',
+        customdata=private.real_expenditure,
+        hovertemplate = '%{customdata:$}',
+        marker=dict(color='rgb(160, 209, 255)',)
+    ))
 
-    fig.add_trace(
-        go.Bar(
-            name="Public Expenditure",
-            y=private["year"].astype(str),
-            x=private.public_percentage,
-            orientation="h",
-            customdata=private.real_expenditure,
-            hovertemplate="%{customdata:$}",
-            marker=dict(
-                color="rgb(17, 141, 255)",
-            ),
-        )
-    )
+    fig.add_trace(go.Bar(
+        name="Public Expenditure",
+        y=private['year'].astype(str),
+        x=private.public_percentage,
+        orientation='h',
+        customdata=private.real_expenditure,
+        hovertemplate = '%{customdata:$}',
+        marker=dict(
+            color='rgb(17, 141, 255)',
+        ),
+    ))
     fig.update_layout(
-        barmode="stack",
+        barmode='stack',
         plot_bgcolor="white",
         legend=dict(orientation="h", yanchor="bottom", y=1),
         title="What % was spent by the govt vs household?",
-        annotations=[
-            dict(
-                xref="paper",
-                yref="paper",
-                x=-0.14,
-                y=-0.2,
-                text="Source: BOOST & CPI: World Bank",
-                showarrow=False,
-                font=dict(size=12),
-            )
-        ],
-    )
-    fig.update_xaxes(tickformat=",.0%")
+        annotations=[dict(
+            xref='paper',
+            yref='paper',
+            x=-0.14,
+            y=-0.2,
+            text="Source: BOOST & CPI: World Bank",
+            showarrow=False,
+            font=dict(size=12)
+        )])
+    fig.update_xaxes(tickformat=',.0%')
 
     return fig
 
-
 @callback(
-    Output("education-outcome", "figure"),
-    Input("stored-data-education-outcome", "data"),
-    Input("stored-data-education-total", "data"),
-    Input("country-select", "value"),
+    Output('education-outcome', 'figure'),
+    Input('stored-data-education-outcome', 'data'),
+    Input('stored-data-education-total', 'data'),
+    Input('country-select', 'value'),
 )
 def render_education_outcome(outcome_data, total_data, country):
     if not total_data or not outcome_data:
-        return
-    indicator = pd.DataFrame(outcome_data["hd_index"])
+        return 
+    indicator = pd.DataFrame(outcome_data['hd_index'])
     indicator = preprocess_df(indicator, country)
     indicator = indicator[indicator.adm1_name == "Total"]
 
-    learning_poverty = pd.DataFrame(outcome_data["learning_poverty"])
+    learning_poverty = pd.DataFrame(outcome_data['learning_poverty'])
     learning_poverty = preprocess_df(learning_poverty, country)
 
-    pub_exp = pd.DataFrame(total_data["edu_public_expenditure"])
+
+    pub_exp = pd.DataFrame(total_data['edu_public_expenditure'])
     pub_exp = preprocess_df(pub_exp, country)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
@@ -377,10 +341,10 @@ def render_education_outcome(outcome_data, total_data, country):
             x=indicator.year,
             y=indicator.education_index,
             mode="lines+markers",
-            line=dict(color="MediumPurple", shape="spline", dash="dot"),
+            line=dict(color='MediumPurple', shape='spline', dash='dot'),
             connectgaps=True,
         ),
-        secondary_y=True,
+        secondary_y=True
     )
 
     fig.add_trace(
@@ -389,10 +353,10 @@ def render_education_outcome(outcome_data, total_data, country):
             x=learning_poverty.year,
             y=learning_poverty.learning_poverty_rate,
             mode="lines+markers",
-            line=dict(color="deeppink", shape="spline", dash="dot"),
+            line=dict(color='deeppink', shape='spline', dash='dot'),
             connectgaps=True,
         ),
-        secondary_y=True,
+        secondary_y=True
     )
 
     fig.add_trace(
@@ -404,37 +368,35 @@ def render_education_outcome(outcome_data, total_data, country):
             marker_color="darkblue",
             opacity=0.6,
         ),
-        secondary_y=False,
+        secondary_y=False
     )
 
     fig.update_layout(
         plot_bgcolor="white",
-        legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=0.9,
-            xanchor="left",
-            x=0,
-            bgcolor="rgba(0,0,0,0)",
-        ),
-        title="How has education outcome changed?",
-        annotations=[
-            dict(
-                xref="paper",
-                yref="paper",
-                x=-0.14,
-                y=-0.25,
-                text="Source: Education index measured by years of education: UNDP through GDL. <br>"
-                "BOOST, CPI, Learning Poverty: World Bank; Population: UN, Eurostat",
-                showarrow=False,
-                font=dict(size=12),
-            )
-        ],
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=0.9,
+                xanchor="left",
+                x=0,
+                bgcolor='rgba(0,0,0,0)'
+            ),
+            title="How has education outcome changed?",
+            annotations=[
+                dict(
+                    xref='paper',
+                    yref='paper',
+                    x=-0.14,
+                    y=-0.25,
+                    text="Source: Education index measured by years of education: UNDP through GDL. <br>"\
+                         "BOOST, CPI, Learning Poverty: World Bank; Population: UN, Eurostat",
+                    showarrow=False,
+                    font=dict(size=12)
+                )]
     )
 
-    fig.update_yaxes(
-        range=[0, max(pub_exp.per_capita_real_expenditure) * 1.2], secondary_y=False
-    )
+    fig.update_yaxes(range=[0, max(pub_exp.per_capita_real_expenditure)*1.2], secondary_y=False)
     fig.update_yaxes(range=[0, 1], secondary_y=True)
 
     return fig
+

--- a/pages/education.py
+++ b/pages/education.py
@@ -5,6 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import queries
+from utils import preprocess_df
 
 dash.register_page(__name__)
 
@@ -181,8 +182,7 @@ def total_edu_figure(df):
 
 def education_narrative(data, country):
     spending = pd.DataFrame(data['edu_public_expenditure'])
-    spending = spending[spending.country_name == country]
-    spending.sort_values(['year'], inplace=True)
+    spending = preprocess_df(spending, country)
 
     start_year = spending.year.min()
     end_year = spending.year.max()
@@ -257,8 +257,7 @@ def render_overview_total_figure(data, country):
     if data is None:
         return None
     all_countries = pd.DataFrame(data['edu_public_expenditure'])
-    df = all_countries[all_countries.country_name == country]
-    df.sort_values(['year'], inplace=True)
+    df = preprocess_df(all_countries, country)
     fig = total_edu_figure(df)
     return fig, education_narrative(data, country)
 
@@ -324,16 +323,15 @@ def render_education_outcome(outcome_data, total_data, country):
     if not total_data or not outcome_data:
         return 
     indicator = pd.DataFrame(outcome_data['hd_index'])
-    indicator = indicator[(indicator.country_name == country) & (indicator.adm1_name == "Total")]
-    indicator.sort_values(['year'],inplace=True)
+    indicator = preprocess_df(indicator, country)
+    indicator = indicator[indicator.adm1_name == "Total"]
 
     learning_poverty = pd.DataFrame(outcome_data['learning_poverty'])
-    learning_poverty = learning_poverty[learning_poverty.country_name == country]
-    learning_poverty.sort_values(['year'], inplace=True)
+    learning_poverty = preprocess_df(learning_poverty, country)
+
 
     pub_exp = pd.DataFrame(total_data['edu_public_expenditure'])
-    pub_exp = pub_exp[pub_exp.country_name == country]
-    pub_exp.sort_values(['year'], inplace=True)
+    pub_exp = preprocess_df(pub_exp, country)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 

--- a/pages/education.py
+++ b/pages/education.py
@@ -9,120 +9,139 @@ from utils import preprocess_df
 
 dash.register_page(__name__)
 
-layout = html.Div(children=[
-    dbc.Card(
-        dbc.CardBody([
-            dbc.Tabs(id='education-tabs', active_tab='edu-tab-time', children=[
-                dbc.Tab(label='Over Time', tab_id='edu-tab-time'),
-                dbc.Tab(label='Across Space', tab_id='edu-tab-space'),
-            ], style={"marginBottom": "2rem"}),
-            html.Div(id='education-content'),
-        ]),
-    ),
-    dcc.Store(id='stored-data-education-total'),
-    dcc.Store(id='stored-data-education-outcome')
-])
+layout = html.Div(
+    children=[
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    dbc.Tabs(
+                        id="education-tabs",
+                        active_tab="edu-tab-time",
+                        children=[
+                            dbc.Tab(label="Over Time", tab_id="edu-tab-time"),
+                            dbc.Tab(label="Across Space", tab_id="edu-tab-space"),
+                        ],
+                        style={"marginBottom": "2rem"},
+                    ),
+                    html.Div(id="education-content"),
+                ]
+            ),
+        ),
+        dcc.Store(id="stored-data-education-total"),
+        dcc.Store(id="stored-data-education-outcome"),
+    ]
+)
 
 
 @callback(
-    Output('stored-data-education-total', 'data'),
-    Input('stored-data-education-total', 'data'),
-    Input('stored-data-func', 'data')
+    Output("stored-data-education-total", "data"),
+    Input("stored-data-education-total", "data"),
+    Input("stored-data-func", "data"),
 )
 def fetch_edu_total_data_once(edu_data, shared_data):
     if edu_data is None:
 
         # filter shared data down to education specific
-        exp_by_func = pd.DataFrame(shared_data['expenditure_by_country_func_year'])
-        pub_exp = exp_by_func[exp_by_func.func == 'Education']
+        exp_by_func = pd.DataFrame(shared_data["expenditure_by_country_func_year"])
+        pub_exp = exp_by_func[exp_by_func.func == "Education"]
 
-        return ({
-            "edu_public_expenditure": pub_exp.to_dict('records'),
-        })
+        return {
+            "edu_public_expenditure": pub_exp.to_dict("records"),
+        }
     return dash.no_update
 
 
 @callback(
-    Output('stored-data-education-outcome', 'data'),
-    Input('stored-data-education-outcome', 'data'),
-    Input('stored-data', 'data')
+    Output("stored-data-education-outcome", "data"),
+    Input("stored-data-education-outcome", "data"),
+    Input("stored-data", "data"),
 )
 def fetch_edu_outcome_data_once(edu_data, shared_data):
     if edu_data is None:
         learning_poverty = queries.get_learning_poverty_rate()
 
-        hd_index = queries.get_hd_index(shared_data['countries'])
+        hd_index = queries.get_hd_index(shared_data["countries"])
 
-        return ({
-            "learning_poverty": learning_poverty.to_dict('records'),
-            "hd_index": hd_index.to_dict('records'),
-        })
+        return {
+            "learning_poverty": learning_poverty.to_dict("records"),
+            "hd_index": hd_index.to_dict("records"),
+        }
     return dash.no_update
 
+
 @callback(
-    Output('education-content', 'children'),
-    Input('education-tabs', 'active_tab'),
+    Output("education-content", "children"),
+    Input("education-tabs", "active_tab"),
 )
 def render_education_content(tab):
-    if tab == 'edu-tab-time':
-        return html.Div([
-            dbc.Row(
-                dbc.Col(
-                    html.H3(
-                        children="Public Spending & Education Outcome",
-                    )
-                )
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.P(
-                        id="education-narrative",
-                        children="loading...",
-                    )
-                )
-            ),
-            dbc.Row(
-                [
-                    # How has total expenditure changed over time?
+    if tab == "edu-tab-time":
+        return html.Div(
+            [
+                dbc.Row(
                     dbc.Col(
-                        dcc.Graph(id="education-total", config={"displayModeBar": False},  ),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                        style={"marginBottom": "3rem"}
-
-                    ),
+                        html.H3(
+                            children="Public Spending & Education Outcome",
+                        )
+                    )
+                ),
+                dbc.Row(
                     dbc.Col(
-                        dcc.Graph(id="education-outcome", config={"displayModeBar": False}, ),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                    ),
-                ],
-            ),
-            dbc.Row(
-                [
-                # How has private expenditure vs public expenditure changed over time?
-                    ## The graph does not look right. Hiding for now
-                    # How has private expenditure vs public expenditure changed over time?
-                    # dbc.Col(
-                    #     dcc.Graph(id="education-public-private", config={"displayModeBar": False},  ),
-                    #     xs={"size": 12, "offset": 0},
-                    #     sm={"size": 12, "offset": 0},
-                    #     md={"size": 12, "offset": 0},
-                    #     lg={"size": 6, "offset": 0},
-                    #     style={"marginBottom": "3rem"}
-                    # ),
-                ],
-            ),
-        ])
-    elif tab == 'edu-tab-space':
-        return html.Div([
-            'Geospatial viz'
-            # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
-        ])
+                        html.P(
+                            id="education-narrative",
+                            children="loading...",
+                        )
+                    )
+                ),
+                dbc.Row(
+                    [
+                        # How has total expenditure changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="education-total",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                            style={"marginBottom": "3rem"},
+                        ),
+                        dbc.Col(
+                            dcc.Graph(
+                                id="education-outcome",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                        ),
+                    ],
+                ),
+                dbc.Row(
+                    [
+                        # How has private expenditure vs public expenditure changed over time?
+                        ## The graph does not look right. Hiding for now
+                        # How has private expenditure vs public expenditure changed over time?
+                        # dbc.Col(
+                        #     dcc.Graph(id="education-public-private", config={"displayModeBar": False},  ),
+                        #     xs={"size": 12, "offset": 0},
+                        #     sm={"size": 12, "offset": 0},
+                        #     md={"size": 12, "offset": 0},
+                        #     lg={"size": 6, "offset": 0},
+                        #     style={"marginBottom": "3rem"}
+                        # ),
+                    ],
+                ),
+            ]
+        )
+    elif tab == "edu-tab-space":
+        return html.Div(
+            [
+                "Geospatial viz"
+                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+            ]
+        )
 
 
 def total_edu_figure(df):
@@ -167,32 +186,35 @@ def total_edu_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
 
+
 def education_narrative(data, country):
-    spending = pd.DataFrame(data['edu_public_expenditure'])
+    spending = pd.DataFrame(data["edu_public_expenditure"])
     spending = preprocess_df(spending, country)
 
     start_year = spending.year.min()
     end_year = spending.year.max()
     start_value = spending[spending.year == start_year].real_expenditure.values[0]
     end_value = spending[spending.year == end_year].real_expenditure.values[0]
-    spending_growth_rate = ((end_value - start_value)/ start_value) * 100
-    text = f'After accounting for inflation, real public spending in education has increased by {spending_growth_rate:.2f}% '\
-    f'between {start_year} and {end_year}. \n'\
-    f'Generally, while education outcomes related to access can be conceptually linked to the availability of public finance, results related to quality have a more complex chain of causality.'\
-    '\n'
+    spending_growth_rate = ((end_value - start_value) / start_value) * 100
+    text = (
+        f"After accounting for inflation, real public spending in education has increased by {spending_growth_rate:.2f}% "
+        f"between {start_year} and {end_year}. \n"
+        f"Generally, while education outcomes related to access can be conceptually linked to the availability of public finance, results related to quality have a more complex chain of causality."
+        "\n"
+    )
     return text
 
 
@@ -234,103 +256,117 @@ def private_public_fig(public, private):
         legend=dict(orientation="h", yanchor="bottom", y=1),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
 
+
 @callback(
-    Output('education-total', 'figure'),
-    Output('education-narrative', 'children'),
-    Input('stored-data-education-total', 'data'),
-    Input('country-select', 'value'),
+    Output("education-total", "figure"),
+    Output("education-narrative", "children"),
+    Input("stored-data-education-total", "data"),
+    Input("country-select", "value"),
 )
 def render_overview_total_figure(data, country):
     if data is None:
         return None
-    all_countries = pd.DataFrame(data['edu_public_expenditure'])
+    all_countries = pd.DataFrame(data["edu_public_expenditure"])
     df = preprocess_df(all_countries, country)
     fig = total_edu_figure(df)
     return fig, education_narrative(data, country)
 
 
 @callback(
-    Output('education-public-private', 'figure'),
-    Input('stored-data-education-outcome', 'data'),
-    Input('country-select', 'value'),
+    Output("education-public-private", "figure"),
+    Input("stored-data-education-outcome", "data"),
+    Input("country-select", "value"),
 )
 def render_public_private_figure(data, country):
-    private = pd.DataFrame(data['edu_private_expenditure'])
+    private = pd.DataFrame(data["edu_private_expenditure"])
     private = private[private.country_name == country]
-    private['private_percentage'] = private['real_expenditure']/(private['real_expenditure'] + private['real_expenditure'])
-    private['public_percentage'] = private['real_expenditure']/(private['real_expenditure'] + private['real_expenditure'])
+    private["private_percentage"] = private["real_expenditure"] / (
+        private["real_expenditure"] + private["real_expenditure"]
+    )
+    private["public_percentage"] = private["real_expenditure"] / (
+        private["real_expenditure"] + private["real_expenditure"]
+    )
 
     fig = go.Figure()
-    fig.add_trace(go.Bar(
-        name="Private Expenditure",
-        y=private["year"].astype(str),
-        x=private.private_percentage,
-        orientation='h',
-        customdata=private.real_expenditure,
-        hovertemplate = '%{customdata:$}',
-        marker=dict(color='rgb(160, 209, 255)',)
-    ))
+    fig.add_trace(
+        go.Bar(
+            name="Private Expenditure",
+            y=private["year"].astype(str),
+            x=private.private_percentage,
+            orientation="h",
+            customdata=private.real_expenditure,
+            hovertemplate="%{customdata:$}",
+            marker=dict(
+                color="rgb(160, 209, 255)",
+            ),
+        )
+    )
 
-    fig.add_trace(go.Bar(
-        name="Public Expenditure",
-        y=private['year'].astype(str),
-        x=private.public_percentage,
-        orientation='h',
-        customdata=private.real_expenditure,
-        hovertemplate = '%{customdata:$}',
-        marker=dict(
-            color='rgb(17, 141, 255)',
-        ),
-    ))
+    fig.add_trace(
+        go.Bar(
+            name="Public Expenditure",
+            y=private["year"].astype(str),
+            x=private.public_percentage,
+            orientation="h",
+            customdata=private.real_expenditure,
+            hovertemplate="%{customdata:$}",
+            marker=dict(
+                color="rgb(17, 141, 255)",
+            ),
+        )
+    )
     fig.update_layout(
-        barmode='stack',
+        barmode="stack",
         plot_bgcolor="white",
         legend=dict(orientation="h", yanchor="bottom", y=1),
         title="What % was spent by the govt vs household?",
-        annotations=[dict(
-            xref='paper',
-            yref='paper',
-            x=-0.14,
-            y=-0.2,
-            text="Source: BOOST & CPI: World Bank",
-            showarrow=False,
-            font=dict(size=12)
-        )])
-    fig.update_xaxes(tickformat=',.0%')
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.14,
+                y=-0.2,
+                text="Source: BOOST & CPI: World Bank",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
+    )
+    fig.update_xaxes(tickformat=",.0%")
 
     return fig
 
+
 @callback(
-    Output('education-outcome', 'figure'),
-    Input('stored-data-education-outcome', 'data'),
-    Input('stored-data-education-total', 'data'),
-    Input('country-select', 'value'),
+    Output("education-outcome", "figure"),
+    Input("stored-data-education-outcome", "data"),
+    Input("stored-data-education-total", "data"),
+    Input("country-select", "value"),
 )
 def render_education_outcome(outcome_data, total_data, country):
     if not total_data or not outcome_data:
-        return 
-    indicator = pd.DataFrame(outcome_data['hd_index'])
+        return
+    indicator = pd.DataFrame(outcome_data["hd_index"])
     indicator = preprocess_df(indicator, country)
     indicator = indicator[indicator.adm1_name == "Total"]
 
-    learning_poverty = pd.DataFrame(outcome_data['learning_poverty'])
+    learning_poverty = pd.DataFrame(outcome_data["learning_poverty"])
     learning_poverty = preprocess_df(learning_poverty, country)
 
-
-    pub_exp = pd.DataFrame(total_data['edu_public_expenditure'])
+    pub_exp = pd.DataFrame(total_data["edu_public_expenditure"])
     pub_exp = preprocess_df(pub_exp, country)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
@@ -341,10 +377,10 @@ def render_education_outcome(outcome_data, total_data, country):
             x=indicator.year,
             y=indicator.education_index,
             mode="lines+markers",
-            line=dict(color='MediumPurple', shape='spline', dash='dot'),
+            line=dict(color="MediumPurple", shape="spline", dash="dot"),
             connectgaps=True,
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
     fig.add_trace(
@@ -353,10 +389,10 @@ def render_education_outcome(outcome_data, total_data, country):
             x=learning_poverty.year,
             y=learning_poverty.learning_poverty_rate,
             mode="lines+markers",
-            line=dict(color='deeppink', shape='spline', dash='dot'),
+            line=dict(color="deeppink", shape="spline", dash="dot"),
             connectgaps=True,
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
     fig.add_trace(
@@ -368,35 +404,37 @@ def render_education_outcome(outcome_data, total_data, country):
             marker_color="darkblue",
             opacity=0.6,
         ),
-        secondary_y=False
+        secondary_y=False,
     )
 
     fig.update_layout(
         plot_bgcolor="white",
-            legend=dict(
-                orientation="h",
-                yanchor="bottom",
-                y=0.9,
-                xanchor="left",
-                x=0,
-                bgcolor='rgba(0,0,0,0)'
-            ),
-            title="How has education outcome changed?",
-            annotations=[
-                dict(
-                    xref='paper',
-                    yref='paper',
-                    x=-0.14,
-                    y=-0.25,
-                    text="Source: Education index measured by years of education: UNDP through GDL. <br>"\
-                         "BOOST, CPI, Learning Poverty: World Bank; Population: UN, Eurostat",
-                    showarrow=False,
-                    font=dict(size=12)
-                )]
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=0.9,
+            xanchor="left",
+            x=0,
+            bgcolor="rgba(0,0,0,0)",
+        ),
+        title="How has education outcome changed?",
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.14,
+                y=-0.25,
+                text="Source: Education index measured by years of education: UNDP through GDL. <br>"
+                "BOOST, CPI, Learning Poverty: World Bank; Population: UN, Eurostat",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
     )
 
-    fig.update_yaxes(range=[0, max(pub_exp.per_capita_real_expenditure)*1.2], secondary_y=False)
+    fig.update_yaxes(
+        range=[0, max(pub_exp.per_capita_real_expenditure) * 1.2], secondary_y=False
+    )
     fig.update_yaxes(range=[0, 1], secondary_y=True)
 
     return fig
-

--- a/pages/health.py
+++ b/pages/health.py
@@ -4,20 +4,32 @@ import dash_bootstrap_components as dbc
 
 dash.register_page(__name__)
 
-layout = html.Div(children=[
-    dbc.Card(
-        dbc.CardBody([
-            dbc.Tabs(id='health-tabs', active_tab='health-tab-time', children=[
-                dbc.Tab(label='Over Time', tab_id='health-tab-time'),
-                dbc.Tab(label='Across Space', tab_id='health-tab-space'),
-            ], style={"marginBottom": "2rem"}),
-            html.Div(id='health-spinner', children=[
-                dbc.Spinner(color="primary", spinner_style={
-                    "width": "3rem", "height": "3rem"
-                }),
-            ]),
-            html.Div(id='health-content'),
-        ])
-    )
-])
-
+layout = html.Div(
+    children=[
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    dbc.Tabs(
+                        id="health-tabs",
+                        active_tab="health-tab-time",
+                        children=[
+                            dbc.Tab(label="Over Time", tab_id="health-tab-time"),
+                            dbc.Tab(label="Across Space", tab_id="health-tab-space"),
+                        ],
+                        style={"marginBottom": "2rem"},
+                    ),
+                    html.Div(
+                        id="health-spinner",
+                        children=[
+                            dbc.Spinner(
+                                color="primary",
+                                spinner_style={"width": "3rem", "height": "3rem"},
+                            ),
+                        ],
+                    ),
+                    html.Div(id="health-content"),
+                ]
+            )
+        )
+    ]
+)

--- a/pages/home.py
+++ b/pages/home.py
@@ -361,6 +361,7 @@ def render_overview_total_figure(data, country):
 def render_overview_total_figure(data, country):
     all_countries = pd.DataFrame(data['expenditure_by_country_func_econ_year'])
     df = all_countries[all_countries.country_name == country]
+    df.sort_values(['year'], inplace=True)
     func_df = df.groupby(['year', 'country_name', 'func'])['expenditure'].sum().reset_index()
 
     total_per_year = func_df.groupby('year')['expenditure'].sum().reset_index()

--- a/pages/home.py
+++ b/pages/home.py
@@ -6,6 +6,9 @@ import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
 
+from utils import preprocess_df
+
+
 dash.register_page(__name__)
 
 layout = html.Div(children=[
@@ -347,7 +350,7 @@ def functional_narrative(df):
 )
 def render_overview_total_figure(data, country):
     all_countries = pd.DataFrame(data['expenditure_w_poverty_by_country_year'])
-    df = all_countries[all_countries.country_name == country]
+    df = preprocess_df(all_countries, country)
 
     return total_figure(df), per_capita_figure(df), overview_narrative(df)
 
@@ -360,8 +363,7 @@ def render_overview_total_figure(data, country):
 )
 def render_overview_total_figure(data, country):
     all_countries = pd.DataFrame(data['expenditure_by_country_func_econ_year'])
-    df = all_countries[all_countries.country_name == country]
-    df.sort_values(['year'], inplace=True)
+    df = preprocess_df(all_countries, country)
     func_df = df.groupby(['year', 'country_name', 'func'])['expenditure'].sum().reset_index()
 
     total_per_year = func_df.groupby('year')['expenditure'].sum().reset_index()

--- a/pages/home.py
+++ b/pages/home.py
@@ -11,101 +11,122 @@ from utils import preprocess_df
 
 dash.register_page(__name__)
 
-layout = html.Div(children=[
-    dbc.Card(
-        dbc.CardBody([
-            dbc.Tabs(id='overview-tabs', active_tab='overview-tab-time', children=[
-                dbc.Tab(label='Over Time', tab_id='overview-tab-time'),
-                dbc.Tab(label='Across Space', tab_id='overview-tab-space'),
-            ], style={"marginBottom": "2rem"}),
-            html.Div(id='overview-content'),
-        ])
-    )
-])
+layout = html.Div(
+    children=[
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    dbc.Tabs(
+                        id="overview-tabs",
+                        active_tab="overview-tab-time",
+                        children=[
+                            dbc.Tab(label="Over Time", tab_id="overview-tab-time"),
+                            dbc.Tab(label="Across Space", tab_id="overview-tab-space"),
+                        ],
+                        style={"marginBottom": "2rem"},
+                    ),
+                    html.Div(id="overview-content"),
+                ]
+            )
+        )
+    ]
+)
 
 
 @callback(
-    Output('overview-content', 'children'),
-    Input('overview-tabs', 'active_tab'),
+    Output("overview-content", "children"),
+    Input("overview-tabs", "active_tab"),
 )
 def render_overview_content(tab):
-    if tab == 'overview-tab-time':
-        return html.Div([
-            dbc.Row(
-                dbc.Col(
-                    html.H3(
-                        children="Total Expenditure",
-                    )
-                )
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.P(
-                        id="overview-narrative",
-                        children="loading...",
-                    )
-                )
-            ),
-            dbc.Row(
-                [
-                    # How has total expenditure changed over time?
+    if tab == "overview-tab-time":
+        return html.Div(
+            [
+                dbc.Row(
                     dbc.Col(
-                        dcc.Graph(id="overview-total", config={"displayModeBar": False}),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                    ),
-                    # How has per capita expenditure changed over time?
-                    dbc.Col(
-                        dcc.Graph(id="overview-per-capita", config={"displayModeBar": False}),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                    ),
-                ],
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.Hr(),
-                )
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.H3(
-                        children="Functional Spending",
+                        html.H3(
+                            children="Total Expenditure",
+                        )
                     )
-                )
-            ),
-            dbc.Row(
-                [
-                    # How has sector prioritization changed over time?
-                    dbc.Col(
-                        dcc.Graph(id="functional-breakdown", config={"displayModeBar": False}),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 8, "offset": 0},
-                    ),
+                ),
+                dbc.Row(
                     dbc.Col(
                         html.P(
-                            id="functional-narrative",
+                            id="overview-narrative",
                             children="loading...",
-                        ),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 4, "offset": 0},
+                        )
                     )
-                ],
-            ),
-        ])
-    elif tab == 'overview-tab-space':
-        return html.Div([
-            'Geospatial viz'
-            # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
-        ])
+                ),
+                dbc.Row(
+                    [
+                        # How has total expenditure changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="overview-total", config={"displayModeBar": False}
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                        ),
+                        # How has per capita expenditure changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="overview-per-capita",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                        ),
+                    ],
+                ),
+                dbc.Row(
+                    dbc.Col(
+                        html.Hr(),
+                    )
+                ),
+                dbc.Row(
+                    dbc.Col(
+                        html.H3(
+                            children="Functional Spending",
+                        )
+                    )
+                ),
+                dbc.Row(
+                    [
+                        # How has sector prioritization changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="functional-breakdown",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 8, "offset": 0},
+                        ),
+                        dbc.Col(
+                            html.P(
+                                id="functional-narrative",
+                                children="loading...",
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 4, "offset": 0},
+                        ),
+                    ],
+                ),
+            ]
+        )
+    elif tab == "overview-tab-space":
+        return html.Div(
+            [
+                "Geospatial viz"
+                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+            ]
+        )
 
 
 def total_figure(df):
@@ -145,15 +166,15 @@ def total_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1.03),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
@@ -168,13 +189,11 @@ def per_capita_figure(df):
             x=df.year,
             y=df.poor215,
             mode="lines+markers",
-            line=dict(color='darkred', shape='spline', dash='dot'),
+            line=dict(color="darkred", shape="spline", dash="dot"),
             connectgaps=True,
-            hovertemplate=(
-                '%{x}: %{y:.2f}%'
-            ),
+            hovertemplate=("%{x}: %{y:.2f}%"),
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
     fig.add_trace(
@@ -185,7 +204,7 @@ def per_capita_figure(df):
             mode="lines+markers",
             marker_color="darkblue",
         ),
-        secondary_y=False
+        secondary_y=False,
     )
     fig.add_trace(
         go.Bar(
@@ -194,7 +213,7 @@ def per_capita_figure(df):
             y=df.per_capita_expenditure,
             marker_color="#686dc3",
         ),
-        secondary_y=False
+        secondary_y=False,
     )
 
     fig.update_xaxes(tickformat="d")
@@ -211,53 +230,82 @@ def per_capita_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1.03),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank; Population: UN, Eurostat",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
+
 
 def overview_narrative(df):
     country = df.country_name.iloc[0]
     earliest = df[df.year == df.earliest_year].iloc[0].to_dict()
     latest = df[df.year == df.latest_year].iloc[0].to_dict()
-    start_year = earliest['year']
-    end_year = latest['year']
+    start_year = earliest["year"]
+    end_year = latest["year"]
     latest_year_with_real_exp = df[df.real_expenditure.notnull()].year.max()
     latest_real_exp = df[df.year == latest_year_with_real_exp].iloc[0].to_dict()
 
-    total_percent_diff = 100 * (latest_real_exp['real_expenditure'] - earliest['real_expenditure']) / earliest['real_expenditure']
-    total_trend = 'increased' if total_percent_diff > 0 else 'decreased'
+    total_percent_diff = (
+        100
+        * (latest_real_exp["real_expenditure"] - earliest["real_expenditure"])
+        / earliest["real_expenditure"]
+    )
+    total_trend = "increased" if total_percent_diff > 0 else "decreased"
 
-    per_capita_percent_diff = 100 * (latest_real_exp['per_capita_real_expenditure'] - earliest['per_capita_real_expenditure']) / earliest['per_capita_real_expenditure']
-    per_capita_trend = 'increased' if per_capita_percent_diff > 0 else 'decreased'
+    per_capita_percent_diff = (
+        100
+        * (
+            latest_real_exp["per_capita_real_expenditure"]
+            - earliest["per_capita_real_expenditure"]
+        )
+        / earliest["per_capita_real_expenditure"]
+    )
+    per_capita_trend = "increased" if per_capita_percent_diff > 0 else "decreased"
 
-    text = f'After accounting for inflation, total public spending has {total_trend} by {total_percent_diff:.1f}% and per capita spending has {per_capita_trend} by {per_capita_percent_diff:.1f}% between {start_year} and {latest_year_with_real_exp}. '
+    text = f"After accounting for inflation, total public spending has {total_trend} by {total_percent_diff:.1f}% and per capita spending has {per_capita_trend} by {per_capita_percent_diff:.1f}% between {start_year} and {latest_year_with_real_exp}. "
 
     decentral_mean = df.expenditure_decentralization.mean() * 100
-    decentral_latest = latest['expenditure_decentralization'] * 100
-    decentral_text = f'On average, {decentral_mean:.1f}% of total public spending is executed by local/regional government. '
+    decentral_latest = latest["expenditure_decentralization"] * 100
+    decentral_text = f"On average, {decentral_mean:.1f}% of total public spending is executed by local/regional government. "
     if decentral_latest > 0:
-        decentral_text += f'In {end_year}, which is the latest year with data available, expenditure decentralization is {decentral_latest:.1f}%. ' 
-    text += decentral_text if decentral_mean > 0 else f'BOOST does not have any local/regional spending data for {country}. '
+        decentral_text += f"In {end_year}, which is the latest year with data available, expenditure decentralization is {decentral_latest:.1f}%. "
+    text += (
+        decentral_text
+        if decentral_mean > 0
+        else f"BOOST does not have any local/regional spending data for {country}. "
+    )
 
     return text
 
 
-COFOG_CATS = ['Social protection', 'Recreation, culture and religion', 'Public order and safety', 'Housing and community amenities', 'Health', 'General public services', 'Environmental protection', 'Education', 'Economic affairs', 'Defence']
+COFOG_CATS = [
+    "Social protection",
+    "Recreation, culture and religion",
+    "Public order and safety",
+    "Housing and community amenities",
+    "Health",
+    "General public services",
+    "Environmental protection",
+    "Education",
+    "Economic affairs",
+    "Defence",
+]
 FUNC_PALETTE = px.colors.qualitative.T10
-FUNC_COLORS = {cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)}
+FUNC_COLORS = {
+    cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)
+}
+
 
 def functional_figure(df):
     categories = sorted(df.func.unique(), reverse=True)
-
 
     fig = go.Figure()
 
@@ -269,10 +317,10 @@ def functional_figure(df):
                 x=cat_df.year,
                 y=cat_df.percentage,
                 marker_color=FUNC_COLORS[cat],
-                customdata=cat_df['expenditure'],
+                customdata=cat_df["expenditure"],
                 hovertemplate=(
-                    '<b>Year</b>: %{x}<br>'
-                    '<b>Expenditure</b>: %{customdata:,} (%{y:.1f}%)'
+                    "<b>Year</b>: %{x}<br>"
+                    "<b>Expenditure</b>: %{customdata:,} (%{y:.1f}%)"
                 ),
             )
         )
@@ -283,91 +331,119 @@ def functional_figure(df):
         barmode="stack",
         title="How has sector prioritization changed over time?",
         plot_bgcolor="white",
-        legend=dict(
-            orientation="v",
-            x=1.02,
-            y=1,
-            xanchor='left',
-            yanchor='top'
-        ),
+        legend=dict(orientation="v", x=1.02, y=1, xanchor="left", yanchor="top"),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.1,
                 y=-0.2,
                 text="Expenditure % by COFOG categories. Source: BOOST",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
 
+
 def functional_narrative(df):
     country = df.country_name.iloc[0]
     categories = df.func.unique().tolist()
-    text = f'For {country}, BOOST provides functional spending data on {len(categories)} categories, based on Classification of the Functions of Government (COFOG). '
+    text = f"For {country}, BOOST provides functional spending data on {len(categories)} categories, based on Classification of the Functions of Government (COFOG). "
 
     if len(categories) < len(COFOG_CATS):
         missing_cats = set(COFOG_CATS) - set(categories)
         if len(missing_cats) == 1:
-            text += f'The cartegory we do not have data on is {list(missing_cats)[0]}. '
+            text += f"The cartegory we do not have data on is {list(missing_cats)[0]}. "
         else:
             text += f'The cartegories we do not have data on include {", ".join(missing_cats)}. '
 
-    mean_percentage = df.groupby('func')['percentage'].mean().reset_index()
+    mean_percentage = df.groupby("func")["percentage"].mean().reset_index()
     n = 3
-    top_funcs = mean_percentage.sort_values(by='percentage', ascending=False).head(n)
-    text += f'On average, the top {n} spending functional categories are '
-    text += ', '.join([f"{row['func']} ({row['percentage']:.1f}%)" for _, row in top_funcs.iterrows()]) + "; "
+    top_funcs = mean_percentage.sort_values(by="percentage", ascending=False).head(n)
+    text += f"On average, the top {n} spending functional categories are "
+    text += (
+        ", ".join(
+            [
+                f"{row['func']} ({row['percentage']:.1f}%)"
+                for _, row in top_funcs.iterrows()
+            ]
+        )
+        + "; "
+    )
 
-    bottom_funcs = mean_percentage.sort_values(by='percentage', ascending=True).head(n)
-    text += f'while the bottom {n} spenders are '
-    text += ', '.join([f"{row['func']} ({row['percentage']:.1f}%)" for _, row in bottom_funcs.iterrows()]) + ". "
+    bottom_funcs = mean_percentage.sort_values(by="percentage", ascending=True).head(n)
+    text += f"while the bottom {n} spenders are "
+    text += (
+        ", ".join(
+            [
+                f"{row['func']} ({row['percentage']:.1f}%)"
+                for _, row in bottom_funcs.iterrows()
+            ]
+        )
+        + ". "
+    )
 
-    std_percentage = df.groupby('func')['percentage'].std().reset_index()
+    std_percentage = df.groupby("func")["percentage"].std().reset_index()
     m = 2
-    stable_funcs = std_percentage.sort_values(by='percentage', ascending=True).head(m)
-    text += f'Relatively, public expenditure remain the most stable in '
-    text += ' and '.join([f"{row['func']} (std={row['percentage']:.1f})" for _, row in stable_funcs.iterrows()]) + "; "
+    stable_funcs = std_percentage.sort_values(by="percentage", ascending=True).head(m)
+    text += f"Relatively, public expenditure remain the most stable in "
+    text += (
+        " and ".join(
+            [
+                f"{row['func']} (std={row['percentage']:.1f})"
+                for _, row in stable_funcs.iterrows()
+            ]
+        )
+        + "; "
+    )
 
-    flux_funcs = std_percentage.sort_values(by='percentage', ascending=False).head(m)
-    text += f'while spending in '
-    text += ' and '.join([f"{row['func']} (std={row['percentage']:.1f})" for _, row in flux_funcs.iterrows()])
-    text += f' fluctuate the most over time. '
+    flux_funcs = std_percentage.sort_values(by="percentage", ascending=False).head(m)
+    text += f"while spending in "
+    text += " and ".join(
+        [
+            f"{row['func']} (std={row['percentage']:.1f})"
+            for _, row in flux_funcs.iterrows()
+        ]
+    )
+    text += f" fluctuate the most over time. "
 
     return text
 
 
 @callback(
-    Output('overview-total', 'figure'),
-    Output('overview-per-capita', 'figure'),
-    Output('overview-narrative', 'children'),
-    Input('stored-data', 'data'),
-    Input('country-select', 'value'),
+    Output("overview-total", "figure"),
+    Output("overview-per-capita", "figure"),
+    Output("overview-narrative", "children"),
+    Input("stored-data", "data"),
+    Input("country-select", "value"),
 )
 def render_overview_total_figure(data, country):
-    all_countries = pd.DataFrame(data['expenditure_w_poverty_by_country_year'])
+    all_countries = pd.DataFrame(data["expenditure_w_poverty_by_country_year"])
     df = preprocess_df(all_countries, country)
 
     return total_figure(df), per_capita_figure(df), overview_narrative(df)
 
 
 @callback(
-    Output('functional-breakdown', 'figure'),
-    Output('functional-narrative', 'children'),
-    Input('stored-data-func', 'data'),
-    Input('country-select', 'value'),
+    Output("functional-breakdown", "figure"),
+    Output("functional-narrative", "children"),
+    Input("stored-data-func", "data"),
+    Input("country-select", "value"),
 )
 def render_overview_total_figure(data, country):
-    all_countries = pd.DataFrame(data['expenditure_by_country_func_econ_year'])
+    all_countries = pd.DataFrame(data["expenditure_by_country_func_econ_year"])
     df = preprocess_df(all_countries, country)
-    func_df = df.groupby(['year', 'country_name', 'func'])['expenditure'].sum().reset_index()
+    func_df = (
+        df.groupby(["year", "country_name", "func"])["expenditure"].sum().reset_index()
+    )
 
-    total_per_year = func_df.groupby('year')['expenditure'].sum().reset_index()
-    func_df = func_df.merge(total_per_year, on='year', suffixes=('', '_total'))
-    func_df['percentage'] = (func_df['expenditure'] / func_df['expenditure_total']) * 100
+    total_per_year = func_df.groupby("year")["expenditure"].sum().reset_index()
+    func_df = func_df.merge(total_per_year, on="year", suffixes=("", "_total"))
+    func_df["percentage"] = (
+        func_df["expenditure"] / func_df["expenditure_total"]
+    ) * 100
 
     return functional_figure(func_df), functional_narrative(func_df)

--- a/pages/home.py
+++ b/pages/home.py
@@ -11,122 +11,101 @@ from utils import preprocess_df
 
 dash.register_page(__name__)
 
-layout = html.Div(
-    children=[
-        dbc.Card(
-            dbc.CardBody(
-                [
-                    dbc.Tabs(
-                        id="overview-tabs",
-                        active_tab="overview-tab-time",
-                        children=[
-                            dbc.Tab(label="Over Time", tab_id="overview-tab-time"),
-                            dbc.Tab(label="Across Space", tab_id="overview-tab-space"),
-                        ],
-                        style={"marginBottom": "2rem"},
-                    ),
-                    html.Div(id="overview-content"),
-                ]
-            )
-        )
-    ]
-)
+layout = html.Div(children=[
+    dbc.Card(
+        dbc.CardBody([
+            dbc.Tabs(id='overview-tabs', active_tab='overview-tab-time', children=[
+                dbc.Tab(label='Over Time', tab_id='overview-tab-time'),
+                dbc.Tab(label='Across Space', tab_id='overview-tab-space'),
+            ], style={"marginBottom": "2rem"}),
+            html.Div(id='overview-content'),
+        ])
+    )
+])
 
 
 @callback(
-    Output("overview-content", "children"),
-    Input("overview-tabs", "active_tab"),
+    Output('overview-content', 'children'),
+    Input('overview-tabs', 'active_tab'),
 )
 def render_overview_content(tab):
-    if tab == "overview-tab-time":
-        return html.Div(
-            [
-                dbc.Row(
-                    dbc.Col(
-                        html.H3(
-                            children="Total Expenditure",
-                        )
+    if tab == 'overview-tab-time':
+        return html.Div([
+            dbc.Row(
+                dbc.Col(
+                    html.H3(
+                        children="Total Expenditure",
                     )
-                ),
-                dbc.Row(
+                )
+            ),
+            dbc.Row(
+                dbc.Col(
+                    html.P(
+                        id="overview-narrative",
+                        children="loading...",
+                    )
+                )
+            ),
+            dbc.Row(
+                [
+                    # How has total expenditure changed over time?
+                    dbc.Col(
+                        dcc.Graph(id="overview-total", config={"displayModeBar": False}),
+                        xs={"size": 12, "offset": 0},
+                        sm={"size": 12, "offset": 0},
+                        md={"size": 12, "offset": 0},
+                        lg={"size": 6, "offset": 0},
+                    ),
+                    # How has per capita expenditure changed over time?
+                    dbc.Col(
+                        dcc.Graph(id="overview-per-capita", config={"displayModeBar": False}),
+                        xs={"size": 12, "offset": 0},
+                        sm={"size": 12, "offset": 0},
+                        md={"size": 12, "offset": 0},
+                        lg={"size": 6, "offset": 0},
+                    ),
+                ],
+            ),
+            dbc.Row(
+                dbc.Col(
+                    html.Hr(),
+                )
+            ),
+            dbc.Row(
+                dbc.Col(
+                    html.H3(
+                        children="Functional Spending",
+                    )
+                )
+            ),
+            dbc.Row(
+                [
+                    # How has sector prioritization changed over time?
+                    dbc.Col(
+                        dcc.Graph(id="functional-breakdown", config={"displayModeBar": False}),
+                        xs={"size": 12, "offset": 0},
+                        sm={"size": 12, "offset": 0},
+                        md={"size": 12, "offset": 0},
+                        lg={"size": 8, "offset": 0},
+                    ),
                     dbc.Col(
                         html.P(
-                            id="overview-narrative",
+                            id="functional-narrative",
                             children="loading...",
-                        )
+                        ),
+                        xs={"size": 12, "offset": 0},
+                        sm={"size": 12, "offset": 0},
+                        md={"size": 12, "offset": 0},
+                        lg={"size": 4, "offset": 0},
                     )
-                ),
-                dbc.Row(
-                    [
-                        # How has total expenditure changed over time?
-                        dbc.Col(
-                            dcc.Graph(
-                                id="overview-total", config={"displayModeBar": False}
-                            ),
-                            xs={"size": 12, "offset": 0},
-                            sm={"size": 12, "offset": 0},
-                            md={"size": 12, "offset": 0},
-                            lg={"size": 6, "offset": 0},
-                        ),
-                        # How has per capita expenditure changed over time?
-                        dbc.Col(
-                            dcc.Graph(
-                                id="overview-per-capita",
-                                config={"displayModeBar": False},
-                            ),
-                            xs={"size": 12, "offset": 0},
-                            sm={"size": 12, "offset": 0},
-                            md={"size": 12, "offset": 0},
-                            lg={"size": 6, "offset": 0},
-                        ),
-                    ],
-                ),
-                dbc.Row(
-                    dbc.Col(
-                        html.Hr(),
-                    )
-                ),
-                dbc.Row(
-                    dbc.Col(
-                        html.H3(
-                            children="Functional Spending",
-                        )
-                    )
-                ),
-                dbc.Row(
-                    [
-                        # How has sector prioritization changed over time?
-                        dbc.Col(
-                            dcc.Graph(
-                                id="functional-breakdown",
-                                config={"displayModeBar": False},
-                            ),
-                            xs={"size": 12, "offset": 0},
-                            sm={"size": 12, "offset": 0},
-                            md={"size": 12, "offset": 0},
-                            lg={"size": 8, "offset": 0},
-                        ),
-                        dbc.Col(
-                            html.P(
-                                id="functional-narrative",
-                                children="loading...",
-                            ),
-                            xs={"size": 12, "offset": 0},
-                            sm={"size": 12, "offset": 0},
-                            md={"size": 12, "offset": 0},
-                            lg={"size": 4, "offset": 0},
-                        ),
-                    ],
-                ),
-            ]
-        )
-    elif tab == "overview-tab-space":
-        return html.Div(
-            [
-                "Geospatial viz"
-                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
-            ]
-        )
+                ],
+            ),
+        ])
+    elif tab == 'overview-tab-space':
+        return html.Div([
+            'Geospatial viz'
+            # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+        ])
 
 
 def total_figure(df):
@@ -166,15 +145,15 @@ def total_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1.03),
         annotations=[
             dict(
-                xref="paper",
-                yref="paper",
+                xref='paper',
+                yref='paper',
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12),
+                font=dict(size=12)
             )
-        ],
+        ]
     )
 
     return fig
@@ -189,11 +168,13 @@ def per_capita_figure(df):
             x=df.year,
             y=df.poor215,
             mode="lines+markers",
-            line=dict(color="darkred", shape="spline", dash="dot"),
+            line=dict(color='darkred', shape='spline', dash='dot'),
             connectgaps=True,
-            hovertemplate=("%{x}: %{y:.2f}%"),
+            hovertemplate=(
+                '%{x}: %{y:.2f}%'
+            ),
         ),
-        secondary_y=True,
+        secondary_y=True
     )
 
     fig.add_trace(
@@ -204,7 +185,7 @@ def per_capita_figure(df):
             mode="lines+markers",
             marker_color="darkblue",
         ),
-        secondary_y=False,
+        secondary_y=False
     )
     fig.add_trace(
         go.Bar(
@@ -213,7 +194,7 @@ def per_capita_figure(df):
             y=df.per_capita_expenditure,
             marker_color="#686dc3",
         ),
-        secondary_y=False,
+        secondary_y=False
     )
 
     fig.update_xaxes(tickformat="d")
@@ -230,82 +211,53 @@ def per_capita_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1.03),
         annotations=[
             dict(
-                xref="paper",
-                yref="paper",
+                xref='paper',
+                yref='paper',
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank; Population: UN, Eurostat",
                 showarrow=False,
-                font=dict(size=12),
+                font=dict(size=12)
             )
-        ],
+        ]
     )
 
     return fig
-
 
 def overview_narrative(df):
     country = df.country_name.iloc[0]
     earliest = df[df.year == df.earliest_year].iloc[0].to_dict()
     latest = df[df.year == df.latest_year].iloc[0].to_dict()
-    start_year = earliest["year"]
-    end_year = latest["year"]
+    start_year = earliest['year']
+    end_year = latest['year']
     latest_year_with_real_exp = df[df.real_expenditure.notnull()].year.max()
     latest_real_exp = df[df.year == latest_year_with_real_exp].iloc[0].to_dict()
 
-    total_percent_diff = (
-        100
-        * (latest_real_exp["real_expenditure"] - earliest["real_expenditure"])
-        / earliest["real_expenditure"]
-    )
-    total_trend = "increased" if total_percent_diff > 0 else "decreased"
+    total_percent_diff = 100 * (latest_real_exp['real_expenditure'] - earliest['real_expenditure']) / earliest['real_expenditure']
+    total_trend = 'increased' if total_percent_diff > 0 else 'decreased'
 
-    per_capita_percent_diff = (
-        100
-        * (
-            latest_real_exp["per_capita_real_expenditure"]
-            - earliest["per_capita_real_expenditure"]
-        )
-        / earliest["per_capita_real_expenditure"]
-    )
-    per_capita_trend = "increased" if per_capita_percent_diff > 0 else "decreased"
+    per_capita_percent_diff = 100 * (latest_real_exp['per_capita_real_expenditure'] - earliest['per_capita_real_expenditure']) / earliest['per_capita_real_expenditure']
+    per_capita_trend = 'increased' if per_capita_percent_diff > 0 else 'decreased'
 
-    text = f"After accounting for inflation, total public spending has {total_trend} by {total_percent_diff:.1f}% and per capita spending has {per_capita_trend} by {per_capita_percent_diff:.1f}% between {start_year} and {latest_year_with_real_exp}. "
+    text = f'After accounting for inflation, total public spending has {total_trend} by {total_percent_diff:.1f}% and per capita spending has {per_capita_trend} by {per_capita_percent_diff:.1f}% between {start_year} and {latest_year_with_real_exp}. '
 
     decentral_mean = df.expenditure_decentralization.mean() * 100
-    decentral_latest = latest["expenditure_decentralization"] * 100
-    decentral_text = f"On average, {decentral_mean:.1f}% of total public spending is executed by local/regional government. "
+    decentral_latest = latest['expenditure_decentralization'] * 100
+    decentral_text = f'On average, {decentral_mean:.1f}% of total public spending is executed by local/regional government. '
     if decentral_latest > 0:
-        decentral_text += f"In {end_year}, which is the latest year with data available, expenditure decentralization is {decentral_latest:.1f}%. "
-    text += (
-        decentral_text
-        if decentral_mean > 0
-        else f"BOOST does not have any local/regional spending data for {country}. "
-    )
+        decentral_text += f'In {end_year}, which is the latest year with data available, expenditure decentralization is {decentral_latest:.1f}%. ' 
+    text += decentral_text if decentral_mean > 0 else f'BOOST does not have any local/regional spending data for {country}. '
 
     return text
 
 
-COFOG_CATS = [
-    "Social protection",
-    "Recreation, culture and religion",
-    "Public order and safety",
-    "Housing and community amenities",
-    "Health",
-    "General public services",
-    "Environmental protection",
-    "Education",
-    "Economic affairs",
-    "Defence",
-]
+COFOG_CATS = ['Social protection', 'Recreation, culture and religion', 'Public order and safety', 'Housing and community amenities', 'Health', 'General public services', 'Environmental protection', 'Education', 'Economic affairs', 'Defence']
 FUNC_PALETTE = px.colors.qualitative.T10
-FUNC_COLORS = {
-    cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)
-}
-
+FUNC_COLORS = {cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)}
 
 def functional_figure(df):
     categories = sorted(df.func.unique(), reverse=True)
+
 
     fig = go.Figure()
 
@@ -317,10 +269,10 @@ def functional_figure(df):
                 x=cat_df.year,
                 y=cat_df.percentage,
                 marker_color=FUNC_COLORS[cat],
-                customdata=cat_df["expenditure"],
+                customdata=cat_df['expenditure'],
                 hovertemplate=(
-                    "<b>Year</b>: %{x}<br>"
-                    "<b>Expenditure</b>: %{customdata:,} (%{y:.1f}%)"
+                    '<b>Year</b>: %{x}<br>'
+                    '<b>Expenditure</b>: %{customdata:,} (%{y:.1f}%)'
                 ),
             )
         )
@@ -331,119 +283,91 @@ def functional_figure(df):
         barmode="stack",
         title="How has sector prioritization changed over time?",
         plot_bgcolor="white",
-        legend=dict(orientation="v", x=1.02, y=1, xanchor="left", yanchor="top"),
+        legend=dict(
+            orientation="v",
+            x=1.02,
+            y=1,
+            xanchor='left',
+            yanchor='top'
+        ),
         annotations=[
             dict(
-                xref="paper",
-                yref="paper",
+                xref='paper',
+                yref='paper',
                 x=-0.1,
                 y=-0.2,
                 text="Expenditure % by COFOG categories. Source: BOOST",
                 showarrow=False,
-                font=dict(size=12),
+                font=dict(size=12)
             )
-        ],
+        ]
     )
 
     return fig
 
-
 def functional_narrative(df):
     country = df.country_name.iloc[0]
     categories = df.func.unique().tolist()
-    text = f"For {country}, BOOST provides functional spending data on {len(categories)} categories, based on Classification of the Functions of Government (COFOG). "
+    text = f'For {country}, BOOST provides functional spending data on {len(categories)} categories, based on Classification of the Functions of Government (COFOG). '
 
     if len(categories) < len(COFOG_CATS):
         missing_cats = set(COFOG_CATS) - set(categories)
         if len(missing_cats) == 1:
-            text += f"The cartegory we do not have data on is {list(missing_cats)[0]}. "
+            text += f'The cartegory we do not have data on is {list(missing_cats)[0]}. '
         else:
             text += f'The cartegories we do not have data on include {", ".join(missing_cats)}. '
 
-    mean_percentage = df.groupby("func")["percentage"].mean().reset_index()
+    mean_percentage = df.groupby('func')['percentage'].mean().reset_index()
     n = 3
-    top_funcs = mean_percentage.sort_values(by="percentage", ascending=False).head(n)
-    text += f"On average, the top {n} spending functional categories are "
-    text += (
-        ", ".join(
-            [
-                f"{row['func']} ({row['percentage']:.1f}%)"
-                for _, row in top_funcs.iterrows()
-            ]
-        )
-        + "; "
-    )
+    top_funcs = mean_percentage.sort_values(by='percentage', ascending=False).head(n)
+    text += f'On average, the top {n} spending functional categories are '
+    text += ', '.join([f"{row['func']} ({row['percentage']:.1f}%)" for _, row in top_funcs.iterrows()]) + "; "
 
-    bottom_funcs = mean_percentage.sort_values(by="percentage", ascending=True).head(n)
-    text += f"while the bottom {n} spenders are "
-    text += (
-        ", ".join(
-            [
-                f"{row['func']} ({row['percentage']:.1f}%)"
-                for _, row in bottom_funcs.iterrows()
-            ]
-        )
-        + ". "
-    )
+    bottom_funcs = mean_percentage.sort_values(by='percentage', ascending=True).head(n)
+    text += f'while the bottom {n} spenders are '
+    text += ', '.join([f"{row['func']} ({row['percentage']:.1f}%)" for _, row in bottom_funcs.iterrows()]) + ". "
 
-    std_percentage = df.groupby("func")["percentage"].std().reset_index()
+    std_percentage = df.groupby('func')['percentage'].std().reset_index()
     m = 2
-    stable_funcs = std_percentage.sort_values(by="percentage", ascending=True).head(m)
-    text += f"Relatively, public expenditure remain the most stable in "
-    text += (
-        " and ".join(
-            [
-                f"{row['func']} (std={row['percentage']:.1f})"
-                for _, row in stable_funcs.iterrows()
-            ]
-        )
-        + "; "
-    )
+    stable_funcs = std_percentage.sort_values(by='percentage', ascending=True).head(m)
+    text += f'Relatively, public expenditure remain the most stable in '
+    text += ' and '.join([f"{row['func']} (std={row['percentage']:.1f})" for _, row in stable_funcs.iterrows()]) + "; "
 
-    flux_funcs = std_percentage.sort_values(by="percentage", ascending=False).head(m)
-    text += f"while spending in "
-    text += " and ".join(
-        [
-            f"{row['func']} (std={row['percentage']:.1f})"
-            for _, row in flux_funcs.iterrows()
-        ]
-    )
-    text += f" fluctuate the most over time. "
+    flux_funcs = std_percentage.sort_values(by='percentage', ascending=False).head(m)
+    text += f'while spending in '
+    text += ' and '.join([f"{row['func']} (std={row['percentage']:.1f})" for _, row in flux_funcs.iterrows()])
+    text += f' fluctuate the most over time. '
 
     return text
 
 
 @callback(
-    Output("overview-total", "figure"),
-    Output("overview-per-capita", "figure"),
-    Output("overview-narrative", "children"),
-    Input("stored-data", "data"),
-    Input("country-select", "value"),
+    Output('overview-total', 'figure'),
+    Output('overview-per-capita', 'figure'),
+    Output('overview-narrative', 'children'),
+    Input('stored-data', 'data'),
+    Input('country-select', 'value'),
 )
 def render_overview_total_figure(data, country):
-    all_countries = pd.DataFrame(data["expenditure_w_poverty_by_country_year"])
+    all_countries = pd.DataFrame(data['expenditure_w_poverty_by_country_year'])
     df = preprocess_df(all_countries, country)
 
     return total_figure(df), per_capita_figure(df), overview_narrative(df)
 
 
 @callback(
-    Output("functional-breakdown", "figure"),
-    Output("functional-narrative", "children"),
-    Input("stored-data-func", "data"),
-    Input("country-select", "value"),
+    Output('functional-breakdown', 'figure'),
+    Output('functional-narrative', 'children'),
+    Input('stored-data-func', 'data'),
+    Input('country-select', 'value'),
 )
 def render_overview_total_figure(data, country):
-    all_countries = pd.DataFrame(data["expenditure_by_country_func_econ_year"])
+    all_countries = pd.DataFrame(data['expenditure_by_country_func_econ_year'])
     df = preprocess_df(all_countries, country)
-    func_df = (
-        df.groupby(["year", "country_name", "func"])["expenditure"].sum().reset_index()
-    )
+    func_df = df.groupby(['year', 'country_name', 'func'])['expenditure'].sum().reset_index()
 
-    total_per_year = func_df.groupby("year")["expenditure"].sum().reset_index()
-    func_df = func_df.merge(total_per_year, on="year", suffixes=("", "_total"))
-    func_df["percentage"] = (
-        func_df["expenditure"] / func_df["expenditure_total"]
-    ) * 100
+    total_per_year = func_df.groupby('year')['expenditure'].sum().reset_index()
+    func_df = func_df.merge(total_per_year, on='year', suffixes=('', '_total'))
+    func_df['percentage'] = (func_df['expenditure'] / func_df['expenditure_total']) * 100
 
     return functional_figure(func_df), functional_narrative(func_df)

--- a/pages/home.py
+++ b/pages/home.py
@@ -6,7 +6,7 @@ import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
 
-from utils import preprocess_df
+from utils import filter_country_sort_year
 
 
 dash.register_page(__name__)
@@ -350,7 +350,7 @@ def functional_narrative(df):
 )
 def render_overview_total_figure(data, country):
     all_countries = pd.DataFrame(data['expenditure_w_poverty_by_country_year'])
-    df = preprocess_df(all_countries, country)
+    df = filter_country_sort_year(all_countries, country)
 
     return total_figure(df), per_capita_figure(df), overview_narrative(df)
 
@@ -363,7 +363,7 @@ def render_overview_total_figure(data, country):
 )
 def render_overview_total_figure(data, country):
     all_countries = pd.DataFrame(data['expenditure_by_country_func_econ_year'])
-    df = preprocess_df(all_countries, country)
+    df = filter_country_sort_year(all_countries, country)
     func_df = df.groupby(['year', 'country_name', 'func'])['expenditure'].sum().reset_index()
 
     total_per_year = func_df.groupby('year')['expenditure'].sum().reset_index()

--- a/pages/home.py
+++ b/pages/home.py
@@ -6,7 +6,6 @@ import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
 
-
 dash.register_page(__name__)
 
 layout = html.Div(children=[
@@ -356,7 +355,7 @@ def render_overview_total_figure(data, country):
 @callback(
     Output('functional-breakdown', 'figure'),
     Output('functional-narrative', 'children'),
-    Input('stored-data', 'data'),
+    Input('stored-data-func', 'data'),
     Input('country-select', 'value'),
 )
 def render_overview_total_figure(data, country):

--- a/pages/home.py
+++ b/pages/home.py
@@ -11,101 +11,122 @@ from utils import filter_country_sort_year
 
 dash.register_page(__name__)
 
-layout = html.Div(children=[
-    dbc.Card(
-        dbc.CardBody([
-            dbc.Tabs(id='overview-tabs', active_tab='overview-tab-time', children=[
-                dbc.Tab(label='Over Time', tab_id='overview-tab-time'),
-                dbc.Tab(label='Across Space', tab_id='overview-tab-space'),
-            ], style={"marginBottom": "2rem"}),
-            html.Div(id='overview-content'),
-        ])
-    )
-])
+layout = html.Div(
+    children=[
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    dbc.Tabs(
+                        id="overview-tabs",
+                        active_tab="overview-tab-time",
+                        children=[
+                            dbc.Tab(label="Over Time", tab_id="overview-tab-time"),
+                            dbc.Tab(label="Across Space", tab_id="overview-tab-space"),
+                        ],
+                        style={"marginBottom": "2rem"},
+                    ),
+                    html.Div(id="overview-content"),
+                ]
+            )
+        )
+    ]
+)
 
 
 @callback(
-    Output('overview-content', 'children'),
-    Input('overview-tabs', 'active_tab'),
+    Output("overview-content", "children"),
+    Input("overview-tabs", "active_tab"),
 )
 def render_overview_content(tab):
-    if tab == 'overview-tab-time':
-        return html.Div([
-            dbc.Row(
-                dbc.Col(
-                    html.H3(
-                        children="Total Expenditure",
-                    )
-                )
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.P(
-                        id="overview-narrative",
-                        children="loading...",
-                    )
-                )
-            ),
-            dbc.Row(
-                [
-                    # How has total expenditure changed over time?
+    if tab == "overview-tab-time":
+        return html.Div(
+            [
+                dbc.Row(
                     dbc.Col(
-                        dcc.Graph(id="overview-total", config={"displayModeBar": False}),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                    ),
-                    # How has per capita expenditure changed over time?
-                    dbc.Col(
-                        dcc.Graph(id="overview-per-capita", config={"displayModeBar": False}),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 6, "offset": 0},
-                    ),
-                ],
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.Hr(),
-                )
-            ),
-            dbc.Row(
-                dbc.Col(
-                    html.H3(
-                        children="Functional Spending",
+                        html.H3(
+                            children="Total Expenditure",
+                        )
                     )
-                )
-            ),
-            dbc.Row(
-                [
-                    # How has sector prioritization changed over time?
-                    dbc.Col(
-                        dcc.Graph(id="functional-breakdown", config={"displayModeBar": False}),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 8, "offset": 0},
-                    ),
+                ),
+                dbc.Row(
                     dbc.Col(
                         html.P(
-                            id="functional-narrative",
+                            id="overview-narrative",
                             children="loading...",
-                        ),
-                        xs={"size": 12, "offset": 0},
-                        sm={"size": 12, "offset": 0},
-                        md={"size": 12, "offset": 0},
-                        lg={"size": 4, "offset": 0},
+                        )
                     )
-                ],
-            ),
-        ])
-    elif tab == 'overview-tab-space':
-        return html.Div([
-            'Geospatial viz'
-            # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
-        ])
+                ),
+                dbc.Row(
+                    [
+                        # How has total expenditure changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="overview-total", config={"displayModeBar": False}
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                        ),
+                        # How has per capita expenditure changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="overview-per-capita",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 6, "offset": 0},
+                        ),
+                    ],
+                ),
+                dbc.Row(
+                    dbc.Col(
+                        html.Hr(),
+                    )
+                ),
+                dbc.Row(
+                    dbc.Col(
+                        html.H3(
+                            children="Functional Spending",
+                        )
+                    )
+                ),
+                dbc.Row(
+                    [
+                        # How has sector prioritization changed over time?
+                        dbc.Col(
+                            dcc.Graph(
+                                id="functional-breakdown",
+                                config={"displayModeBar": False},
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 8, "offset": 0},
+                        ),
+                        dbc.Col(
+                            html.P(
+                                id="functional-narrative",
+                                children="loading...",
+                            ),
+                            xs={"size": 12, "offset": 0},
+                            sm={"size": 12, "offset": 0},
+                            md={"size": 12, "offset": 0},
+                            lg={"size": 4, "offset": 0},
+                        ),
+                    ],
+                ),
+            ]
+        )
+    elif tab == "overview-tab-space":
+        return html.Div(
+            [
+                "Geospatial viz"
+                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+            ]
+        )
 
 
 def total_figure(df):
@@ -145,15 +166,15 @@ def total_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1.03),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
@@ -168,13 +189,11 @@ def per_capita_figure(df):
             x=df.year,
             y=df.poor215,
             mode="lines+markers",
-            line=dict(color='darkred', shape='spline', dash='dot'),
+            line=dict(color="darkred", shape="spline", dash="dot"),
             connectgaps=True,
-            hovertemplate=(
-                '%{x}: %{y:.2f}%'
-            ),
+            hovertemplate=("%{x}: %{y:.2f}%"),
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
     fig.add_trace(
@@ -185,7 +204,7 @@ def per_capita_figure(df):
             mode="lines+markers",
             marker_color="darkblue",
         ),
-        secondary_y=False
+        secondary_y=False,
     )
     fig.add_trace(
         go.Bar(
@@ -194,7 +213,7 @@ def per_capita_figure(df):
             y=df.per_capita_expenditure,
             marker_color="#686dc3",
         ),
-        secondary_y=False
+        secondary_y=False,
     )
 
     fig.update_xaxes(tickformat="d")
@@ -211,53 +230,82 @@ def per_capita_figure(df):
         legend=dict(orientation="h", yanchor="bottom", y=1.03),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.14,
                 y=-0.2,
                 text="Source: BOOST & CPI: World Bank; Population: UN, Eurostat",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
+
 
 def overview_narrative(df):
     country = df.country_name.iloc[0]
     earliest = df[df.year == df.earliest_year].iloc[0].to_dict()
     latest = df[df.year == df.latest_year].iloc[0].to_dict()
-    start_year = earliest['year']
-    end_year = latest['year']
+    start_year = earliest["year"]
+    end_year = latest["year"]
     latest_year_with_real_exp = df[df.real_expenditure.notnull()].year.max()
     latest_real_exp = df[df.year == latest_year_with_real_exp].iloc[0].to_dict()
 
-    total_percent_diff = 100 * (latest_real_exp['real_expenditure'] - earliest['real_expenditure']) / earliest['real_expenditure']
-    total_trend = 'increased' if total_percent_diff > 0 else 'decreased'
+    total_percent_diff = (
+        100
+        * (latest_real_exp["real_expenditure"] - earliest["real_expenditure"])
+        / earliest["real_expenditure"]
+    )
+    total_trend = "increased" if total_percent_diff > 0 else "decreased"
 
-    per_capita_percent_diff = 100 * (latest_real_exp['per_capita_real_expenditure'] - earliest['per_capita_real_expenditure']) / earliest['per_capita_real_expenditure']
-    per_capita_trend = 'increased' if per_capita_percent_diff > 0 else 'decreased'
+    per_capita_percent_diff = (
+        100
+        * (
+            latest_real_exp["per_capita_real_expenditure"]
+            - earliest["per_capita_real_expenditure"]
+        )
+        / earliest["per_capita_real_expenditure"]
+    )
+    per_capita_trend = "increased" if per_capita_percent_diff > 0 else "decreased"
 
-    text = f'After accounting for inflation, total public spending has {total_trend} by {total_percent_diff:.1f}% and per capita spending has {per_capita_trend} by {per_capita_percent_diff:.1f}% between {start_year} and {latest_year_with_real_exp}. '
+    text = f"After accounting for inflation, total public spending has {total_trend} by {total_percent_diff:.1f}% and per capita spending has {per_capita_trend} by {per_capita_percent_diff:.1f}% between {start_year} and {latest_year_with_real_exp}. "
 
     decentral_mean = df.expenditure_decentralization.mean() * 100
-    decentral_latest = latest['expenditure_decentralization'] * 100
-    decentral_text = f'On average, {decentral_mean:.1f}% of total public spending is executed by local/regional government. '
+    decentral_latest = latest["expenditure_decentralization"] * 100
+    decentral_text = f"On average, {decentral_mean:.1f}% of total public spending is executed by local/regional government. "
     if decentral_latest > 0:
-        decentral_text += f'In {end_year}, which is the latest year with data available, expenditure decentralization is {decentral_latest:.1f}%. ' 
-    text += decentral_text if decentral_mean > 0 else f'BOOST does not have any local/regional spending data for {country}. '
+        decentral_text += f"In {end_year}, which is the latest year with data available, expenditure decentralization is {decentral_latest:.1f}%. "
+    text += (
+        decentral_text
+        if decentral_mean > 0
+        else f"BOOST does not have any local/regional spending data for {country}. "
+    )
 
     return text
 
 
-COFOG_CATS = ['Social protection', 'Recreation, culture and religion', 'Public order and safety', 'Housing and community amenities', 'Health', 'General public services', 'Environmental protection', 'Education', 'Economic affairs', 'Defence']
+COFOG_CATS = [
+    "Social protection",
+    "Recreation, culture and religion",
+    "Public order and safety",
+    "Housing and community amenities",
+    "Health",
+    "General public services",
+    "Environmental protection",
+    "Education",
+    "Economic affairs",
+    "Defence",
+]
 FUNC_PALETTE = px.colors.qualitative.T10
-FUNC_COLORS = {cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)}
+FUNC_COLORS = {
+    cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)
+}
+
 
 def functional_figure(df):
     categories = sorted(df.func.unique(), reverse=True)
-
 
     fig = go.Figure()
 
@@ -269,10 +317,10 @@ def functional_figure(df):
                 x=cat_df.year,
                 y=cat_df.percentage,
                 marker_color=FUNC_COLORS[cat],
-                customdata=cat_df['expenditure'],
+                customdata=cat_df["expenditure"],
                 hovertemplate=(
-                    '<b>Year</b>: %{x}<br>'
-                    '<b>Expenditure</b>: %{customdata:,} (%{y:.1f}%)'
+                    "<b>Year</b>: %{x}<br>"
+                    "<b>Expenditure</b>: %{customdata:,} (%{y:.1f}%)"
                 ),
             )
         )
@@ -283,91 +331,119 @@ def functional_figure(df):
         barmode="stack",
         title="How has sector prioritization changed over time?",
         plot_bgcolor="white",
-        legend=dict(
-            orientation="v",
-            x=1.02,
-            y=1,
-            xanchor='left',
-            yanchor='top'
-        ),
+        legend=dict(orientation="v", x=1.02, y=1, xanchor="left", yanchor="top"),
         annotations=[
             dict(
-                xref='paper',
-                yref='paper',
+                xref="paper",
+                yref="paper",
                 x=-0.1,
                 y=-0.2,
                 text="Expenditure % by COFOG categories. Source: BOOST",
                 showarrow=False,
-                font=dict(size=12)
+                font=dict(size=12),
             )
-        ]
+        ],
     )
 
     return fig
 
+
 def functional_narrative(df):
     country = df.country_name.iloc[0]
     categories = df.func.unique().tolist()
-    text = f'For {country}, BOOST provides functional spending data on {len(categories)} categories, based on Classification of the Functions of Government (COFOG). '
+    text = f"For {country}, BOOST provides functional spending data on {len(categories)} categories, based on Classification of the Functions of Government (COFOG). "
 
     if len(categories) < len(COFOG_CATS):
         missing_cats = set(COFOG_CATS) - set(categories)
         if len(missing_cats) == 1:
-            text += f'The cartegory we do not have data on is {list(missing_cats)[0]}. '
+            text += f"The cartegory we do not have data on is {list(missing_cats)[0]}. "
         else:
             text += f'The cartegories we do not have data on include {", ".join(missing_cats)}. '
 
-    mean_percentage = df.groupby('func')['percentage'].mean().reset_index()
+    mean_percentage = df.groupby("func")["percentage"].mean().reset_index()
     n = 3
-    top_funcs = mean_percentage.sort_values(by='percentage', ascending=False).head(n)
-    text += f'On average, the top {n} spending functional categories are '
-    text += ', '.join([f"{row['func']} ({row['percentage']:.1f}%)" for _, row in top_funcs.iterrows()]) + "; "
+    top_funcs = mean_percentage.sort_values(by="percentage", ascending=False).head(n)
+    text += f"On average, the top {n} spending functional categories are "
+    text += (
+        ", ".join(
+            [
+                f"{row['func']} ({row['percentage']:.1f}%)"
+                for _, row in top_funcs.iterrows()
+            ]
+        )
+        + "; "
+    )
 
-    bottom_funcs = mean_percentage.sort_values(by='percentage', ascending=True).head(n)
-    text += f'while the bottom {n} spenders are '
-    text += ', '.join([f"{row['func']} ({row['percentage']:.1f}%)" for _, row in bottom_funcs.iterrows()]) + ". "
+    bottom_funcs = mean_percentage.sort_values(by="percentage", ascending=True).head(n)
+    text += f"while the bottom {n} spenders are "
+    text += (
+        ", ".join(
+            [
+                f"{row['func']} ({row['percentage']:.1f}%)"
+                for _, row in bottom_funcs.iterrows()
+            ]
+        )
+        + ". "
+    )
 
-    std_percentage = df.groupby('func')['percentage'].std().reset_index()
+    std_percentage = df.groupby("func")["percentage"].std().reset_index()
     m = 2
-    stable_funcs = std_percentage.sort_values(by='percentage', ascending=True).head(m)
-    text += f'Relatively, public expenditure remain the most stable in '
-    text += ' and '.join([f"{row['func']} (std={row['percentage']:.1f})" for _, row in stable_funcs.iterrows()]) + "; "
+    stable_funcs = std_percentage.sort_values(by="percentage", ascending=True).head(m)
+    text += f"Relatively, public expenditure remain the most stable in "
+    text += (
+        " and ".join(
+            [
+                f"{row['func']} (std={row['percentage']:.1f})"
+                for _, row in stable_funcs.iterrows()
+            ]
+        )
+        + "; "
+    )
 
-    flux_funcs = std_percentage.sort_values(by='percentage', ascending=False).head(m)
-    text += f'while spending in '
-    text += ' and '.join([f"{row['func']} (std={row['percentage']:.1f})" for _, row in flux_funcs.iterrows()])
-    text += f' fluctuate the most over time. '
+    flux_funcs = std_percentage.sort_values(by="percentage", ascending=False).head(m)
+    text += f"while spending in "
+    text += " and ".join(
+        [
+            f"{row['func']} (std={row['percentage']:.1f})"
+            for _, row in flux_funcs.iterrows()
+        ]
+    )
+    text += f" fluctuate the most over time. "
 
     return text
 
 
 @callback(
-    Output('overview-total', 'figure'),
-    Output('overview-per-capita', 'figure'),
-    Output('overview-narrative', 'children'),
-    Input('stored-data', 'data'),
-    Input('country-select', 'value'),
+    Output("overview-total", "figure"),
+    Output("overview-per-capita", "figure"),
+    Output("overview-narrative", "children"),
+    Input("stored-data", "data"),
+    Input("country-select", "value"),
 )
 def render_overview_total_figure(data, country):
-    all_countries = pd.DataFrame(data['expenditure_w_poverty_by_country_year'])
+    all_countries = pd.DataFrame(data["expenditure_w_poverty_by_country_year"])
     df = filter_country_sort_year(all_countries, country)
 
     return total_figure(df), per_capita_figure(df), overview_narrative(df)
 
 
 @callback(
-    Output('functional-breakdown', 'figure'),
-    Output('functional-narrative', 'children'),
-    Input('stored-data-func', 'data'),
-    Input('country-select', 'value'),
+    Output("functional-breakdown", "figure"),
+    Output("functional-narrative", "children"),
+    Input("stored-data-func", "data"),
+    Input("country-select", "value"),
 )
 def render_overview_total_figure(data, country):
-    all_countries = pd.DataFrame(data['expenditure_by_country_func_econ_year'])
+    all_countries = pd.DataFrame(data["expenditure_by_country_func_econ_year"])
     df = filter_country_sort_year(all_countries, country)
-    func_df = df.groupby(['year', 'country_name', 'func'])['expenditure'].sum().reset_index()
+    func_df = (
+        df.groupby(["year", "country_name", "func"])["expenditure"].sum().reset_index()
+    )
 
-    total_per_year = func_df.groupby('year')['expenditure'].sum().reset_index()
-    func_df = func_df.merge(total_per_year, on='year', suffixes=('', '_total'))
-    func_df['percentage'] = (func_df['expenditure'] / func_df['expenditure_total']) * 100
+    total_per_year = func_df.groupby("year")["expenditure"].sum().reset_index()
+    func_df = func_df.merge(total_per_year, on="year", suffixes=("", "_total"))
+    func_df["percentage"] = (
+        func_df["expenditure"] / func_df["expenditure_total"]
+    ) * 100
 
     return functional_figure(func_df), functional_narrative(func_df)

--- a/queries.py
+++ b/queries.py
@@ -49,7 +49,6 @@ def get_expenditure_by_country_func_year():
     query = '''
         SELECT *
         FROM boost.expenditure_by_country_func_year
-        ORDER BY country_name, func, year
     '''
     end = time.time()
     df = execute_query(query)
@@ -87,7 +86,6 @@ def get_learning_poverty_rate():
     start = time.time()
     query = '''
         SELECT * FROM indicator.learning_poverty_rate
-        ORDER BY country_name, year
     '''
     df = execute_query(query)
     end = time.time()
@@ -98,7 +96,6 @@ def get_expenditure_by_country_func_econ_year():
     start = time.time()
     query = """
         SELECT * FROM boost.expenditure_by_country_func_econ_year
-        ORDER BY country_name, func, econ, year
     """
     df = execute_query(query)
     end = time.time()

--- a/queries.py
+++ b/queries.py
@@ -1,7 +1,6 @@
 import os
 import pandas as pd
 from databricks import sql
-import time
 
 SERVER_HOSTNAME = os.getenv("SERVER_HOSTNAME")
 HTTP_PATH = os.getenv("HTTP_PATH")
@@ -30,71 +29,53 @@ def execute_query(dbsql_query):
 
 
 def get_expenditure_w_porverty_by_country_year():
-    start = time.time()
     df = execute_query("""
         SELECT *
         FROM boost.pov_expenditure_by_country_year
     """)
     df['decentralized_expenditure'].fillna(0, inplace=True)
-    end = time.time()
-    print('get_expenditure_w_porverty_by_country_year', end-start )
     return df
 
 #TODO add the filter by the years
 def get_expenditure_by_country_func_year():
-    start = time.time()
     query = '''
         SELECT *
         FROM boost.expenditure_by_country_func_year
     '''
-    end = time.time()
     df = execute_query(query)
-    print("get_expenditure_by_country_func_year", end-start)
     return df
 
 #TODO add the filter by the years
 def get_edu_private_expenditure():
-    start = time.time()
     query = '''
         SELECT country_name, year, real_expenditure
         FROM boost.edu_private_expenditure_by_country_year
         ORDER BY country_name, year
     '''
     df = execute_query(query)
-    end = time.time()
-    print("get_edu_private_expenditure", end-start)
     return df
 
 # The full dataset is big therefore requiring the list of countries for filtering
 def get_hd_index(countries):
-    start =time.time()
     query= '''
         SELECT * FROM indicator.global_data_lab_hd_index
     '''
     country_list = "', '".join(countries)
     query += f" WHERE country_name IN ('{country_list}')"
     query += ' ORDER BY country_name, year'
-    end = time.time()
     df =  execute_query(query)
-    print(" get_hd_index", end-start)
     return df
 
 def get_learning_poverty_rate():
-    start = time.time()
     query = '''
         SELECT * FROM indicator.learning_poverty_rate
     '''
     df = execute_query(query)
-    end = time.time()
-    print("get_learning_poverty_rate", end - start)
     return df
 
 def get_expenditure_by_country_func_econ_year():
-    start = time.time()
     query = """
         SELECT * FROM boost.expenditure_by_country_func_econ_year
     """
     df = execute_query(query)
-    end = time.time()
-    print("get_expenditure_by_country_func_econ_year", end-start)
     return df

--- a/queries.py
+++ b/queries.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 from databricks import sql
+import time
 
 SERVER_HOSTNAME = os.getenv("SERVER_HOSTNAME")
 HTTP_PATH = os.getenv("HTTP_PATH")
@@ -29,6 +30,7 @@ def execute_query(dbsql_query):
 
 
 def get_expenditure_w_porverty_by_country_year():
+    start = time.time()
     df = execute_query("""
         SELECT e.*, p.poor215
         FROM boost.expenditure_by_country_year e
@@ -37,45 +39,68 @@ def get_expenditure_w_porverty_by_country_year():
         ORDER BY e.country_name, e.year
     """)
     df['decentralized_expenditure'].fillna(0, inplace=True)
+    end = time.time()
+    print('get_expenditure_w_porverty_by_country_year', end-start )
     return df
 
 #TODO add the filter by the years
 def get_expenditure_by_country_func_year():
+    start = time.time()
     query = '''
         SELECT *
         FROM boost.expenditure_by_country_func_year
         ORDER BY country_name, func, year
     '''
-    return execute_query(query)
+    end = time.time()
+    df = execute_query(query)
+    print("get_expenditure_by_country_func_year", end-start)
+    return df
 
 #TODO add the filter by the years
 def get_edu_private_expenditure():
+    start = time.time()
     query = '''
         SELECT country_name, year, real_expenditure
         FROM boost.edu_private_expenditure_by_country_year
         ORDER BY country_name, year
     '''
-    return execute_query(query)
+    df = execute_query(query)
+    end = time.time()
+    print("get_edu_private_expenditure", end-start)
+    return df
 
 # The full dataset is big therefore requiring the list of countries for filtering
 def get_hd_index(countries):
+    start =time.time()
     query= '''
         SELECT * FROM indicator.global_data_lab_hd_index
     '''
     country_list = "', '".join(countries)
     query += f" WHERE country_name IN ('{country_list}')"
     query += ' ORDER BY country_name, year'
-    return execute_query(query)
+    end = time.time()
+    df =  execute_query(query)
+    print(" get_hd_index", end-start)
+    return df
 
 def get_learning_poverty_rate():
+    start = time.time()
     query = '''
         SELECT * FROM indicator.learning_poverty_rate
         ORDER BY country_name, year
     '''
-    return execute_query(query)
+    df = execute_query(query)
+    end = time.time()
+    print("get_learning_poverty_rate", end - start)
+    return df
 
 def get_expenditure_by_country_func_econ_year():
-    return execute_query("""
+    start = time.time()
+    query = """
         SELECT * FROM boost.expenditure_by_country_func_econ_year
         ORDER BY country_name, func, econ, year
-    """)
+    """
+    df = execute_query(query)
+    end = time.time()
+    print("get_expenditure_by_country_func_econ_year", end-start)
+    return df

--- a/queries.py
+++ b/queries.py
@@ -32,11 +32,8 @@ def execute_query(dbsql_query):
 def get_expenditure_w_porverty_by_country_year():
     start = time.time()
     df = execute_query("""
-        SELECT e.*, p.poor215
-        FROM boost.expenditure_by_country_year e
-        LEFT JOIN indicator.poverty p
-          ON e.country_name = p.country_name AND e.year = p.year
-        ORDER BY e.country_name, e.year
+        SELECT *
+        FROM boost.pov_expenditure_by_country_year
     """)
     df['decentralized_expenditure'].fillna(0, inplace=True)
     end = time.time()

--- a/queries.py
+++ b/queries.py
@@ -6,6 +6,7 @@ SERVER_HOSTNAME = os.getenv("SERVER_HOSTNAME")
 HTTP_PATH = os.getenv("HTTP_PATH")
 ACCESS_TOKEN = os.getenv("ACCESS_TOKEN")
 
+
 def execute_query(dbsql_query):
     """
     Fetches data from the Databricks database and returns it as a pandas dataframe
@@ -29,49 +30,56 @@ def execute_query(dbsql_query):
 
 
 def get_expenditure_w_porverty_by_country_year():
-    df = execute_query("""
+    df = execute_query(
+        """
         SELECT *
         FROM boost.pov_expenditure_by_country_year
-    """)
-    df['decentralized_expenditure'].fillna(0, inplace=True)
+    """
+    )
+    df["decentralized_expenditure"].fillna(0, inplace=True)
     return df
 
-#TODO add the filter by the years
+
+# TODO add the filter by the years
 def get_expenditure_by_country_func_year():
-    query = '''
+    query = """
         SELECT *
         FROM boost.expenditure_by_country_func_year
-    '''
+    """
     df = execute_query(query)
     return df
 
-#TODO add the filter by the years
+
+# TODO add the filter by the years
 def get_edu_private_expenditure():
-    query = '''
+    query = """
         SELECT country_name, year, real_expenditure
         FROM boost.edu_private_expenditure_by_country_year
         ORDER BY country_name, year
-    '''
+    """
     df = execute_query(query)
     return df
+
 
 # The full dataset is big therefore requiring the list of countries for filtering
 def get_hd_index(countries):
-    query= '''
+    query = """
         SELECT * FROM indicator.global_data_lab_hd_index
-    '''
+    """
     country_list = "', '".join(countries)
     query += f" WHERE country_name IN ('{country_list}')"
-    query += ' ORDER BY country_name, year'
-    df =  execute_query(query)
-    return df
-
-def get_learning_poverty_rate():
-    query = '''
-        SELECT * FROM indicator.learning_poverty_rate
-    '''
+    query += " ORDER BY country_name, year"
     df = execute_query(query)
     return df
+
+
+def get_learning_poverty_rate():
+    query = """
+        SELECT * FROM indicator.learning_poverty_rate
+    """
+    df = execute_query(query)
+    return df
+
 
 def get_expenditure_by_country_func_econ_year():
     query = """

--- a/queries.py
+++ b/queries.py
@@ -6,7 +6,6 @@ SERVER_HOSTNAME = os.getenv("SERVER_HOSTNAME")
 HTTP_PATH = os.getenv("HTTP_PATH")
 ACCESS_TOKEN = os.getenv("ACCESS_TOKEN")
 
-
 def execute_query(dbsql_query):
     """
     Fetches data from the Databricks database and returns it as a pandas dataframe
@@ -30,56 +29,49 @@ def execute_query(dbsql_query):
 
 
 def get_expenditure_w_porverty_by_country_year():
-    df = execute_query(
-        """
+    df = execute_query("""
         SELECT *
         FROM boost.pov_expenditure_by_country_year
-    """
-    )
-    df["decentralized_expenditure"].fillna(0, inplace=True)
+    """)
+    df['decentralized_expenditure'].fillna(0, inplace=True)
     return df
 
-
-# TODO add the filter by the years
+#TODO add the filter by the years
 def get_expenditure_by_country_func_year():
-    query = """
+    query = '''
         SELECT *
         FROM boost.expenditure_by_country_func_year
-    """
+    '''
     df = execute_query(query)
     return df
 
-
-# TODO add the filter by the years
+#TODO add the filter by the years
 def get_edu_private_expenditure():
-    query = """
+    query = '''
         SELECT country_name, year, real_expenditure
         FROM boost.edu_private_expenditure_by_country_year
         ORDER BY country_name, year
-    """
+    '''
     df = execute_query(query)
     return df
-
 
 # The full dataset is big therefore requiring the list of countries for filtering
 def get_hd_index(countries):
-    query = """
+    query= '''
         SELECT * FROM indicator.global_data_lab_hd_index
-    """
+    '''
     country_list = "', '".join(countries)
     query += f" WHERE country_name IN ('{country_list}')"
-    query += " ORDER BY country_name, year"
-    df = execute_query(query)
+    query += ' ORDER BY country_name, year'
+    df =  execute_query(query)
     return df
-
 
 def get_learning_poverty_rate():
-    query = """
+    query = '''
         SELECT * FROM indicator.learning_poverty_rate
-    """
+    '''
     df = execute_query(query)
     return df
-
 
 def get_expenditure_by_country_func_econ_year():
     query = """

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-def preprocess_df(df, country):
+def filter_country_sort_year(df, country):
     """
     Preprocess the dataframe to filter by country and sort by year
     :param df: DataFrame

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,10 @@
+def preprocess_df(df, country):
+    """
+    Preprocess the dataframe to filter by country and sort by year
+    :param df: DataFrame
+    :param country: str
+    :return: DataFrame
+    """
+    df = df.loc[df["country_name"] == country]
+    df = df.sort_values(["year"])
+    return df


### PR DESCRIPTION
Tried the following: 

1. Async rendering - now the query should be mapped to a specific plot. This enables a specific plot to be rendered after only the relevant queries are completed.
2. Pushed down ORDER opearation after the filtering (now the filtering is done by Pandas)
3. Pre-execution of the queries. (the new tables are created in this PR. https://github.com/dime-worldbank/mega-boost/pull/17)

|                                            | Before (seconds) | After (seconds) | Methods                                              |
|--------------------------------------------|------------------|-----------------|------------------------------------------------------|
| get_expenditure_w_porverty_by_country_year | 2.871            | 0.651           | 1. SORT OPERATION PUSHDOWN  2. Pre-join in databricks |
| get_expenditure_by_country_func_econ_year  | 2.017            | 0.763           | 1. SORT OPERATION PUSHDOWN                           |
| get_expenditure_by_country_func_year       | 3.099e-06        | 0.00            | 1. SORT OPERATION PUSHDOWN                           |
| get_learning_poverty_rate                  | 1.668            | 0.713           | 1. SORT OPERATION PUSHDOWN                           |
| get_hd_index                               | 4.053e-06        | 5.198e-06       | 1. SORT OPERATION PUSHDOWN                           |