### PR TITLE
Subnational plots

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,7 @@ app.layout = html.Div(
         content,
         dummy_div,
         dcc.Store(id="stored-data"),
+        dcc.Store(id="stored-data-subnational"),
         dcc.Store(id="stored-data-func"),
     ]
 )
@@ -99,7 +100,7 @@ def redirect_default(url_pathname):
 @app.callback(Output("stored-data", "data"), Input("stored-data", "data"))
 def fetch_data_once(data):
     if data is None:
-        df = queries.get_expenditure_w_porverty_by_country_year()
+        df = queries.get_expenditure_w_poverty_by_country_year()
         countries = sorted(df["country_name"].unique())
         return {
             "countries": countries,
@@ -116,6 +117,25 @@ def fetch_func_data_once(data):
         return {
             "expenditure_by_country_func_econ_year": func_econ_df.to_dict("records"),
             "expenditure_by_country_func_year": func_df.to_dict("records"),
+        }
+    return dash.no_update
+
+
+@app.callback(
+    Output("stored-data-subnational", "data"),
+    Input("stored-data-subnational", "data"),
+    Input("stored-data", "data"),
+)
+def fetch_subnational_data_once(data, country_data):
+    countries = country_data["countries"]
+    if data is None:
+        boundaries_geojson = queries.get_adm_boundaries(countries)
+        subnational_poverty_df = queries.get_subnational_poverty_index()
+        geo1_year_df = queries.get_expenditure_by_country_geo1_year()
+        return {
+            "subnational_poverty_index": subnational_poverty_df.to_dict("records"),
+            "boundaries": boundaries_geojson,
+            "expenditure_by_country_geo1_year": geo1_year_df.to_dict("records"),
         }
     return dash.no_update
 

--- a/pages/home.py
+++ b/pages/home.py
@@ -548,10 +548,10 @@ def subnational_spending_narrative(
             corr_narrative = f"The correlation between per capita spending and poverty rates is {correlation:.2f},\
                 indicating a strong inverse relationship. Higher per capita spending is generally associated with lower poverty rates."
         elif abs(correlation) > corr_thresholds[0]:
-            corr_narrative = f"The correlation between per capita spending and poverty rates is {correlation:.2f} (Pearson correlation coefficient), \
+            corr_narrative = f"The correlation between per capita spending and poverty rates is {correlation:.2f}, \
                 suggesting a moderate inverse relationship. Generally, higher per capita spending is associated with lower poverty, though exceptions exist."
         else:
-            corr_narrative = f"The correlation between per capita spending and poverty rates is {correlation:.2f} (Pearson correlation coefficient), \
+            corr_narrative = f"The correlation between per capita spending and poverty rates is {correlation:.2f}, \
                 indicating a weak inverse relationship. There is little consistent pattern between higher per capita spending and poverty rates."
     else:
         corr_narrative = ""

--- a/pages/home.py
+++ b/pages/home.py
@@ -5,9 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
-
-from utils import filter_country_sort_year
-
+from utils import filter_country_sort_year, map_center, filter_geojson_by_country, zoom
 
 dash.register_page(__name__)
 
@@ -123,8 +121,76 @@ def render_overview_content(tab):
     elif tab == "overview-tab-space":
         return html.Div(
             [
-                "Geospatial viz"
-                # dcc.Graph(id='overview-plot', figure=make_overview_plot(gdp, country))
+                dbc.Row(
+                    dbc.Col(
+                        html.H3(
+                            children="Regional Expenditure",
+                        )
+                    )
+                ),
+                # "Geospatial choropleths"
+                dcc.Loading(
+                    type="dot",
+                    children=[
+                        dbc.Row(
+                            [
+                                # How much was spent in each region?
+                                dbc.Col(
+                                    dcc.Graph(
+                                        id="subnational-spending",
+                                        config={"displayModeBar": False},
+                                    ),
+                                    xs={"size": 12, "offset": 0},
+                                    sm={"size": 12, "offset": 0},
+                                    md={"size": 12, "offset": 0},
+                                    lg={"size": 6, "offset": 0},
+                                ),
+                                # How much was spent per person in each region?
+                                dbc.Col(
+                                    dcc.Graph(
+                                        id="subnational-percapita-spending",
+                                        config={"displayModeBar": False},
+                                    ),
+                                    xs={"size": 12, "offset": 0},
+                                    sm={"size": 12, "offset": 0},
+                                    md={"size": 12, "offset": 0},
+                                    lg={"size": 6, "offset": 0},
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                html.Div(style={"height": "20px"}),
+                dcc.Loading(
+                    type="dot",
+                    children=[
+                        dbc.Row(
+                            [
+                                # How has percapita expenditure in each region changed oevr time?
+                                dbc.Col(
+                                    dcc.Graph(
+                                        id="subnational-percapita-time-change",
+                                        config={"displayModeBar": False},
+                                    ),
+                                    xs={"size": 12, "offset": 0},
+                                    sm={"size": 12, "offset": 0},
+                                    md={"size": 12, "offset": 0},
+                                    lg={"size": 6, "offset": 0},
+                                ),
+                                dbc.Col(
+                                    dcc.Graph(
+                                        id="subnational-poverty",
+                                        config={"displayModeBar": False},
+                                    ),
+                                    xs={"size": 12, "offset": 0},
+                                    sm={"size": 12, "offset": 0},
+                                    md={"size": 12, "offset": 0},
+                                    lg={"size": 6, "offset": 0},
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
             ]
         )
 
@@ -413,6 +479,209 @@ def functional_narrative(df):
     return text
 
 
+def regional_spending_choropleth(geojson, df):
+    all_regions = [feature["properties"]["region"] for feature in geojson["features"]]
+    regions_without_data = [r for r in all_regions if r not in df.adm1_name.values]
+    df_no_data = pd.DataFrame({"region_name": regions_without_data})
+    df_no_data["adm1_name"] = None
+
+    fig = px.choropleth_mapbox(
+        df,
+        geojson=geojson,
+        color="expenditure",
+        locations="adm1_name",
+        featureidkey="properties.region",
+        center=map_center(geojson),
+        mapbox_style="carto-positron",
+        zoom=zoom.get(df.country_name.iloc[0], 6),
+    )
+    fig.add_trace(
+        px.choropleth_mapbox(
+            df_no_data,
+            geojson=geojson,
+            color_discrete_sequence=["rgba(211, 211, 211, 0.3)"],
+            locations="region_name",
+            featureidkey="properties.region",
+            zoom=zoom.get(df.country_name.iloc[0], 6),
+        ).data[0]
+    )
+    fig.update_layout(
+        title="How much was spent in each region?",
+        plot_bgcolor="white",
+        coloraxis_colorbar=dict(
+            title="",
+            orientation="v",
+            thickness=10,
+        ),
+        legend=dict(orientation="h", x=1.02, y=1, xanchor="left", yanchor="top"),
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.1,
+                y=-0.2,
+                text="Regional spending. Source: BOOST",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
+    )
+    fig.update_traces(
+        hovertemplate="<b>Region:</b> %{location}<br>" + "<b>Expenditure:</b> %{z}<br>"
+    )
+
+    return fig
+
+
+def regional_percapita_spending_choropleth(geojson, df):
+    all_regions = [feature["properties"]["region"] for feature in geojson["features"]]
+    regions_without_data = [r for r in all_regions if r not in df.adm1_name.values]
+    df_no_data = pd.DataFrame({"region_name": regions_without_data})
+    df_no_data["adm1_name"] = None
+
+    fig = px.choropleth_mapbox(
+        df,
+        geojson=geojson,
+        color="per_capita_expenditure",
+        locations="adm1_name",
+        featureidkey="properties.region",
+        center=map_center(geojson),
+        mapbox_style="carto-positron",
+        zoom=zoom.get(df.country_name.iloc[0], 6),
+    )
+    fig.add_trace(
+        px.choropleth_mapbox(
+            df_no_data,
+            geojson=geojson,
+            color_discrete_sequence=["rgba(211, 211, 211, 0.3)"],
+            locations="region_name",
+            featureidkey="properties.region",
+            zoom=zoom.get(df.country_name.iloc[0], 6),
+        ).data[0]
+    )
+    fig.update_layout(
+        title="How much was spent per person in each region?",
+        plot_bgcolor="white",
+        coloraxis_colorbar=dict(
+            title="",
+            orientation="v",
+            thickness=10,
+        ),
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.15,
+                y=-0.2,
+                text="Per capita regional spending. Source: BOOST",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
+    )
+    fig.update_traces(
+        hovertemplate="<b>Region:</b> %{location}<br>"
+        + "<b>Per capita expenditure:</b> %{z}<br>"
+        + "<extra></extra>"
+    )
+
+    return fig
+
+
+def subnational_spending_heatmap(df):
+    df = df[df.adm1_name != "Central Scope"]
+    df_pivot = df.pivot(
+        index="adm1_name", columns="year", values="per_capita_expenditure"
+    )
+    fig = px.imshow(df_pivot, x=df_pivot.columns, y=df_pivot.index)
+    fig.update_layout(
+        title="How has per capita regional expenditure changed over time?",
+        plot_bgcolor="white",
+        xaxis_title="",
+        yaxis_title="",
+        coloraxis_colorbar=dict(
+            title="", orientation="v", thickness=10, tickformat=".2~s"
+        ),
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.17,
+                y=-0.2,
+                text="Per capita regional expenditure. Source: BOOST",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
+        # width=500,height=500
+    )
+    fig.update_traces(
+        hovertemplate="<b>Region:</b> %{y}<br>"
+        + "<b>Year:</b> %{x}<br>"
+        + "<b>Expenditure:</b> %{z:.2s}<br>"
+        + "<extra></extra>"
+    )
+
+    return fig
+
+
+def subnational_poverty_choropleth(geojson, df):
+    poverty_col = "poor215"
+    max_year = df.year.max()
+    df = df[df.year == max_year]
+    country_name = df.country_name.iloc[0]
+    all_regions = [feature["properties"]["region"] for feature in geojson["features"]]
+    regions_without_data = [r for r in all_regions if r not in df.region_name.values]
+    df_no_data = pd.DataFrame({"region_name": regions_without_data})
+    df_no_data[poverty_col] = None
+    fig = px.choropleth_mapbox(
+        df,
+        geojson=geojson,
+        color=poverty_col,
+        locations="region_name",
+        featureidkey="properties.region",
+        center=map_center(geojson),
+        zoom=zoom.get(country_name, 3),
+        mapbox_style="carto-positron",
+    )
+    fig.add_trace(
+        px.choropleth_mapbox(
+            df_no_data,
+            geojson=geojson,
+            color_discrete_sequence=["rgba(211, 211, 211, 0.3)"],
+            locations="region_name",
+            featureidkey="properties.region",
+            zoom=zoom.get(country_name, 3),
+        ).data[0]
+    )
+    fig.update_layout(
+        title="What percent of the population is living in poverty?",
+        plot_bgcolor="white",
+        coloraxis_colorbar=dict(
+            title="",
+            orientation="v",
+            thickness=10,
+        ),
+        annotations=[
+            dict(
+                xref="paper",
+                yref="paper",
+                x=-0.15,
+                y=-0.2,
+                text=f"Poverty rate - {poverty_col}. Source: SPID and GSAP, World Bank",
+                showarrow=False,
+                font=dict(size=12),
+            )
+        ],
+    )
+    fig.update_traces(
+        hovertemplate="<b>Region:</b> %{location}<br>"
+        + "<b>Poverty rate (2.15):</b> %{z}<br>"
+    )
+
+    return fig
+
+
 @callback(
     Output("overview-total", "figure"),
     Output("overview-per-capita", "figure"),
@@ -423,7 +692,6 @@ def functional_narrative(df):
 def render_overview_total_figure(data, country):
     all_countries = pd.DataFrame(data["expenditure_w_poverty_by_country_year"])
     df = filter_country_sort_year(all_countries, country)
-
     return total_figure(df), per_capita_figure(df), overview_narrative(df)
 
 
@@ -447,3 +715,39 @@ def render_overview_total_figure(data, country):
     ) * 100
 
     return functional_figure(func_df), functional_narrative(func_df)
+
+
+@callback(
+    Output("subnational-spending", "figure"),
+    Output("subnational-percapita-spending", "figure"),
+    Output("subnational-percapita-time-change", "figure"),
+    Input("stored-data-subnational", "data"),
+    Input("country-select", "value"),
+)
+def render_subnational_spending_figures(data, country):
+    geojson = data["boundaries"]
+    filtered_geojson = filter_geojson_by_country(geojson, country)
+    df = pd.DataFrame(data["expenditure_by_country_geo1_year"])
+    df = filter_country_sort_year(df, country)
+    max_year = df.year.max()
+    ddf = df[(df.year == max_year) & (df.adm1_name != "Central Scope")]
+
+    return (
+        regional_spending_choropleth(filtered_geojson, ddf),
+        regional_percapita_spending_choropleth(filtered_geojson, ddf),
+        subnational_spending_heatmap(df),
+    )
+
+
+@callback(
+    Output("subnational-poverty", "figure"),
+    Input("stored-data-subnational", "data"),
+    Input("country-select", "value"),
+)
+def render_subnational_poverty_figure(data, country):
+    geojson = data["boundaries"]
+    filtered_geojson = filter_geojson_by_country(geojson, country)
+    df = pd.DataFrame(data["subnational_poverty_index"])
+    df = filter_country_sort_year(df, country)
+
+    return subnational_poverty_choropleth(filtered_geojson, df)

--- a/pages/home.py
+++ b/pages/home.py
@@ -11,6 +11,7 @@ from utils import (
     filter_geojson_by_country,
     zoom,
     empty_plot,
+    remove_accents,
 )
 
 dash.register_page(__name__)
@@ -549,6 +550,7 @@ def regional_percapita_spending_choropleth(geojson, df):
     if df.empty:
         return empty_plot("Sub-national population data not available ")
     country_name = df.country_name.iloc[0]
+    df = df[df.adm1_name != "Central Scope"]
     fig = px.choropleth_mapbox(
         df,
         geojson=geojson,
@@ -639,9 +641,11 @@ def subnational_spending_heatmap(df):
 
 
 def subnational_poverty_choropleth(geojson, df):
+
     if df[df.region_name != "National"].empty:
         return empty_plot("Sub-national poverty data not available")
-
+    # TODO align accents across all datasets
+    df["region_name"] = df.region_name.map(lambda x: remove_accents(x))
     poverty_col = "poor215"
     max_year = df.year.max()
     df = df[df.year == max_year]

--- a/pages/home.py
+++ b/pages/home.py
@@ -5,6 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
+import numpy as np
 from utils import (
     filter_country_sort_year,
     map_center,
@@ -131,6 +132,7 @@ def render_overview_content(tab):
                 dbc.Row(
                     dbc.Col(
                         html.H3(
+                            id="regional-expenditure-heading",
                             children="Regional Expenditure",
                         )
                     )
@@ -141,13 +143,18 @@ def render_overview_content(tab):
                     [
                         dbc.Col(width=1),
                         dbc.Col(
-                            dcc.Slider(
-                                id="year-slider",
-                                min=0,
-                                max=0,
-                                value=None,
-                                step=None,
-                                included=False,
+                            html.Div(
+                                id="year-slider-container",
+                                children=[
+                                    dcc.Slider(
+                                        id="year-slider",
+                                        min=0,
+                                        max=0,
+                                        value=None,
+                                        step=None,
+                                        included=False,
+                                    ),
+                                ],
                             ),
                             width=10,
                         ),
@@ -744,6 +751,16 @@ def subnational_poverty_choropleth(geojson, df, zmin, zmax, lat, lon):
 
 
 @callback(
+    Output("regional-expenditure-heading", "children"),
+    Input("country-select", "value"),
+)
+def update_heading(country):
+    if not country:
+        return "Regional Expenditure"
+    return f"{country} Regional Expenditure"
+
+
+@callback(
     Output("overview-total", "figure"),
     Output("overview-per-capita", "figure"),
     Output("overview-narrative", "children"),
@@ -779,6 +796,7 @@ def render_overview_total_figure(data, country):
 
 
 @callback(
+    Output("year-slider-container", "style"),
     Output("year-slider", "marks"),
     Output("year-slider", "value"),
     Output("year-slider", "min"),
@@ -790,6 +808,11 @@ def update_year_range(data, country):
     data = data["basic_country_info"]
     expenditure_years = data[country].get("expenditure_years", [])
     poverty_years = data[country].get("poverty_years", [])
+
+    if not expenditure_years:
+        # Hide the slider if there are no expenditure years
+        return {"display": "none"}, {}, 0, 0, 0
+
     common_years = set(poverty_years).intersection(set(expenditure_years))
     min_year, max_year = expenditure_years[0], expenditure_years[-1]
 
@@ -803,7 +826,7 @@ def update_year_range(data, country):
     }
 
     selected_year = max_year
-    return marks, selected_year, min_year, max_year
+    return {"display": "block"}, marks, selected_year, min_year, max_year
 
 
 @callback(
@@ -815,9 +838,12 @@ def update_year_range(data, country):
     Input("year-slider", "value"),
 )
 def render_subnational_spending_figures(data, country_data, country, plot_type, year):
+    if year is None or not data or not country_data or not country:
+        return empty_plot("Data not available")
+
     geojson = data["boundaries"]
     lat, lon = [
-        country_data["basic_country_info"][country][k]
+        country_data["basic_country_info"][country].get(k)
         for k in ["latitude", "longitude"]
     ]
 
@@ -825,6 +851,10 @@ def render_subnational_spending_figures(data, country_data, country, plot_type, 
     df = pd.DataFrame(data["expenditure_by_country_geo1_year"])
     df = filter_country_sort_year(df, country)
     df = df[df.adm1_name != "Central Scope"]
+
+    if df.empty or year not in df.year.unique():
+        return empty_plot("No expenditure data available for the selected year")
+
     legend_percapita_min, legend_percapita_max = (
         df.per_capita_expenditure.min(),
         df.per_capita_expenditure.max(),
@@ -833,6 +863,7 @@ def render_subnational_spending_figures(data, country_data, country, plot_type, 
         df.expenditure.min(),
         df.expenditure.max(),
     )
+
     if plot_type == "percapita":
         return regional_percapita_spending_choropleth(
             filtered_geojson,
@@ -861,21 +892,30 @@ def render_subnational_spending_figures(data, country_data, country, plot_type, 
     Input("year-slider", "value"),
 )
 def render_subnational_poverty_figure(subnational_data, country_data, country, year):
+    if year is None or not subnational_data or not country_data or not country:
+        return empty_plot("Data not available")
+
     geojson = subnational_data["boundaries"]
     filtered_geojson = filter_geojson_by_country(geojson, country)
     df = pd.DataFrame(subnational_data["subnational_poverty_index"])
     df = filter_country_sort_year(df, country)
-    legend_min, legend_max = country_data["basic_country_info"][country][
-        "poverty_bounds"
-    ]
+
+    legend_min, legend_max = country_data["basic_country_info"][country].get(
+        "poverty_bounds", (None, None)
+    )
     lat, lon = [
-        country_data["basic_country_info"][country][k]
+        country_data["basic_country_info"][country].get(k)
         for k in ["latitude", "longitude"]
     ]
-    available_years = country_data["basic_country_info"][country]["poverty_years"]
+
+    available_years = country_data["basic_country_info"][country].get(
+        "poverty_years", []
+    )
     relevant_years = [x for x in available_years if x <= year]
-    if not relevant_years:
+
+    if not relevant_years or df.empty:
         return empty_plot("Poverty data not available for this time period")
+
     return subnational_poverty_choropleth(
         filtered_geojson,
         df[df.year == relevant_years[-1]],
@@ -896,18 +936,27 @@ def render_subnational_poverty_figure(subnational_data, country_data, country, y
 def render_subnational_spending_narrative(
     subnational_data, country_data, country, year
 ):
+    if year is None or not subnational_data or not country_data or not country:
+        return "Data not available"
+
     df_poverty = pd.DataFrame(subnational_data["subnational_poverty_index"])
     df_poverty = filter_country_sort_year(df_poverty, country)
-    available_years = country_data["basic_country_info"][country]["poverty_years"]
+
+    available_years = country_data["basic_country_info"][country].get(
+        "poverty_years", []
+    )
     relevant_years = [x for x in available_years if x <= year]
-    if not relevant_years:
+
+    if not relevant_years or df_poverty.empty:
         df_poverty = pd.DataFrame()
-    else:
-        df_poverty = df_poverty[df_poverty.year == relevant_years[-1]]
 
     df_spending = pd.DataFrame(subnational_data["expenditure_by_country_geo1_year"])
     df_spending = filter_country_sort_year(df_spending, country)
     df_spending = df_spending[
         (df_spending.adm1_name != "Central Scope") & (df_spending.year == year)
     ]
+
+    if df_spending.empty:
+        return "No spending data available"
+
     return subnational_spending_narrative(df_spending, df_poverty)

--- a/queries.py
+++ b/queries.py
@@ -100,7 +100,7 @@ def get_expenditure_by_country_geo1_year():
 
 def get_adm_boundaries(countries):
     query = """
-        SELECT * FROM indicator.admin1_boundaries
+        SELECT * FROM indicator.admin1_boundaries_gold
     """
     country_list = "', '".join(countries)
     query += f" WHERE country_name IN ('{country_list}')"

--- a/queries.py
+++ b/queries.py
@@ -90,6 +90,16 @@ def get_expenditure_by_country_func_econ_year():
     return df
 
 
+def get_basic_country_data(countries):
+    country_list = "', '".join(countries)
+    query = """
+        SELECT * FROM indicator.country
+    """
+    query += f" WHERE country_name IN ('{country_list}')"
+    df = execute_query(query)
+    return df
+
+
 def get_expenditure_by_country_geo1_year():
     query = """
         SELECT * FROM boost.expenditure_by_country_geo1_year
@@ -119,9 +129,11 @@ def get_adm_boundaries(countries):
     return geojson
 
 
-def get_subnational_poverty_index():
+def get_subnational_poverty_index(countries):
+    country_list = "', '".join(countries)
     query = """
         SELECT * FROM indicator.subnational_poverty_index
     """
+    query += f" WHERE country_name IN ('{country_list}')"
     df = execute_query(query)
     return df

--- a/queries.py
+++ b/queries.py
@@ -93,7 +93,7 @@ def get_expenditure_by_country_func_econ_year():
 def get_basic_country_data(countries):
     country_list = "', '".join(countries)
     query = """
-        SELECT * FROM indicator.country
+        SELECT country_name, longitude, latitude, income_level FROM indicator.country
     """
     query += f" WHERE country_name IN ('{country_list}')"
     df = execute_query(query)
@@ -102,7 +102,7 @@ def get_basic_country_data(countries):
 
 def get_expenditure_by_country_geo1_year():
     query = """
-        SELECT * FROM boost.expenditure_by_country_geo1_year
+        SELECT country_name, year, adm1_name, expenditure, per_capita_expenditure FROM boost.expenditure_by_country_geo1_year
     """
     df = execute_query(query)
     return df
@@ -110,23 +110,13 @@ def get_expenditure_by_country_geo1_year():
 
 def get_adm_boundaries(countries):
     query = """
-        SELECT * FROM indicator.admin1_boundaries_gold
+        SELECT country_name, admin1_region, boundary FROM indicator.admin1_boundaries_gold
     """
     country_list = "', '".join(countries)
     query += f" WHERE country_name IN ('{country_list}')"
     query += " ORDER BY country_name"
     df = execute_query(query)
-    geojson = {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "properties": {"country": x[0], "region": x[1]},
-                "geometry": json.loads(x[2]),
-            }
-            for x in zip(df.country_name, df.admin1_region, df.boundary)
-        ],
-    }
-    return geojson
+    return df
 
 
 def get_subnational_poverty_index(countries):

--- a/queries.py
+++ b/queries.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pandas as pd
 from databricks import sql
 
@@ -29,7 +30,7 @@ def execute_query(dbsql_query):
     return df
 
 
-def get_expenditure_w_porverty_by_country_year():
+def get_expenditure_w_poverty_by_country_year():
     df = execute_query(
         """
         SELECT *
@@ -84,6 +85,43 @@ def get_learning_poverty_rate():
 def get_expenditure_by_country_func_econ_year():
     query = """
         SELECT * FROM boost.expenditure_by_country_func_econ_year
+    """
+    df = execute_query(query)
+    return df
+
+
+def get_expenditure_by_country_geo1_year():
+    query = """
+        SELECT * FROM boost.expenditure_by_country_geo1_year
+    """
+    df = execute_query(query)
+    return df
+
+
+def get_adm_boundaries(countries):
+    query = """
+        SELECT * FROM indicator.admin1_boundaries
+    """
+    country_list = "', '".join(countries)
+    query += f" WHERE country_name IN ('{country_list}')"
+    query += " ORDER BY country_name"
+    df = execute_query(query)
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "properties": {"country": x[0], "region": x[1]},
+                "geometry": json.loads(x[2]),
+            }
+            for x in zip(df.country_name, df.admin1_region, df.boundary)
+        ],
+    }
+    return geojson
+
+
+def get_subnational_poverty_index():
+    query = """
+        SELECT * FROM indicator.subnational_poverty_index
     """
     df = execute_query(query)
     return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ rsconnect-python
 databricks-sql-connector
 dash[diskcache]
 gunicorn
-python-dotenv
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ rsconnect-python
 databricks-sql-connector
 dash[diskcache]
 gunicorn
+python-dotenv
+shapely

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from shapely.geometry import shape, MultiPolygon, Polygon
+import plotly.graph_objects as go
 
 
 def filter_country_sort_year(df, country):
@@ -48,6 +49,21 @@ def map_center(geojson):
     center_lat, center_lon = (centroid.y, centroid.x)
 
     return {"lat": center_lat, "lon": center_lon}
+
+
+def empty_plot(message):
+    fig = go.Figure()
+    fig.add_annotation(
+        text=message,
+        xref="paper",
+        yref="paper",
+        showarrow=False,
+        font=dict(size=14),
+    )
+    fig.update_layout(
+        xaxis={"visible": False}, yaxis={"visible": False}, plot_bgcolor="white"
+    )
+    return fig
 
 
 zoom = {

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 from shapely.geometry import shape, MultiPolygon, Polygon
 import plotly.graph_objects as go
+import unicodedata
 
 
 def filter_country_sort_year(df, country):
@@ -64,6 +65,12 @@ def empty_plot(message):
         xaxis={"visible": False}, yaxis={"visible": False}, plot_bgcolor="white"
     )
     return fig
+
+
+def remove_accents(input_str):
+    normalized_str = unicodedata.normalize("NFD", input_str)
+    stripped_str = "".join(c for c in normalized_str if not unicodedata.combining(c))
+    return stripped_str
 
 
 zoom = {

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,6 @@
+from shapely.geometry import shape, MultiPolygon, Polygon
+
+
 def filter_country_sort_year(df, country):
     """
     Preprocess the dataframe to filter by country and sort by year
@@ -8,3 +11,55 @@ def filter_country_sort_year(df, country):
     df = df.loc[df["country_name"] == country]
     df = df.sort_values(["year"])
     return df
+
+
+def filter_geojson_by_country(geojson, country):
+    """Filter geojson object by country
+    Params:
+        geojson (GeoJSON object): input geojson
+        country:  str
+    """
+    filtered_features = [
+        feature
+        for feature in geojson["features"]
+        if feature["properties"].get("country") == country
+    ]
+    filtered_geojson = {"type": "FeatureCollection", "features": filtered_features}
+    return filtered_geojson
+
+
+def map_center(geojson):
+    polygons = []
+    for feature in geojson["features"]:
+        geom = shape(feature["geometry"])
+        if isinstance(geom, Polygon):  # If it's a single Polygon, add it directly
+            polygons.append(geom)
+        elif isinstance(
+            geom, MultiPolygon
+        ):  # If it's a MultiPolygon, extend the list with its polygons
+            polygons.extend(geom.geoms)
+
+    if len(polygons) > 1:
+        multi_polygon = MultiPolygon(polygons)
+    else:
+        multi_polygon = polygons[0]
+
+    centroid = multi_polygon.centroid
+    center_lat, center_lon = (centroid.y, centroid.x)
+
+    return {"lat": center_lat, "lon": center_lon}
+
+
+zoom = {
+    "Albania": 5.7,
+    "Bangladesh": 5,
+    "Bhutan": 6,
+    "Burkina Faso": 4.7,
+    "Colombia": 3.6,
+    "Kenya": 4.35,
+    "Mozambique": 3.35,
+    "Nigeria": 4.2,
+    "Pakistan": 3.7,
+    "Paraguay": 4.4,
+    "Tunisia": 4.5,
+}


### PR DESCRIPTION
@yukinko-iwasaki 
This essentially adds 'Total expenditure;, 'Per-capita expenditure', and 'sub-national poverty' plots to the 'Across Space' tab in the app. 
Includes:
1. Fetching data from the boost subnational expenditure table, boundaries from the subnational boundaries table and poverty data at the subnational level. I use the same cache method -- with the Store key subnational-data to receive and then later retrieve from. 
2. Since there is a need to see available data by years (due to the slider and the need to show most recent data for poverty) I made a basic-country-data dictionary to reduce the need to query for this data repeatedly. This is added to the Store as well. 
3. I followed similar naming schemes as before for function names -- where render_.. is used for the final rendering of the figure etc.

Note:
1. The correction of the region names (adm0 and adm1) are not incorporated yet. Once the table structure is decided then this would result in potentially changing a column name here.
2. I have retained my old method of rendering the empty plot. This modification will be made shortly