### PR TITLE
Add a disclaimer for maps

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,4 +1,4 @@
-.disclaimer-div .tooltip-inner {
+.disclaimer-tooltip.tooltip .tooltip-inner {
     max-width: 500px !important;
     white-space: normal !important;
     color: white !important;

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,0 +1,5 @@
+.disclaimer-div .tooltip-inner {
+    max-width: 500px !important;
+    white-space: normal !important;
+    color: white !important;
+}

--- a/components/disclaimer_div.py
+++ b/components/disclaimer_div.py
@@ -1,0 +1,29 @@
+from dash import html
+import dash_bootstrap_components as dbc
+
+
+def disclaimer_tooltip(disclaimer_id, tooltip_text):
+    return html.Div(
+        [
+            html.Span(
+                "disclaimer",
+                id=disclaimer_id,
+                style={
+                    "color": "CCCCCC",
+                    "fontSize": "12px",
+                    "textDecoration": "underline dotted",
+                    "cursor": "pointer",
+                    "fontWeight": "bold",
+                    "marginLeft": "8px",
+                },
+            ),
+            dbc.Tooltip(
+                tooltip_text,
+                target=disclaimer_id,
+                placement="top",
+                style={"fontSize": "14px"},
+                className='disclaimer-tooltip'
+            ),
+        ],
+        style={"display": "flex", "alignItems": "center"},
+    )

--- a/constants.py
+++ b/constants.py
@@ -29,4 +29,6 @@ FUNC_COLORS = {
     cat: FUNC_PALETTE[i % len(FUNC_PALETTE)] for i, cat in enumerate(COFOG_CATS)
 }
 
-
+MAP_DISCLAIMER = "Country borders or names do not necessarily reflect the World Bank Group's official position." \
+"This map is for illustrative purposes and does not imply the expression of any opinion on the part of the World Bank," \
+"concerning the legal status of any country or territory or concerning the delimitation of frontiers or boundaries."

--- a/pages/education.py
+++ b/pages/education.py
@@ -27,6 +27,7 @@ from components.edu_health_across_space import (
     update_hd_index_map,
     render_func_subnat_rank,
 )
+from components.disclaimer_div import disclaimer_tooltip
 
 db = QueryService.get_instance()
 
@@ -310,51 +311,26 @@ def render_education_content(tab):
                 dbc.Row(
                     html.Div(
                         [
-                            html.Div(
-                                dbc.RadioItems(
-                                    id="education-expenditure-type",
-                                    options=[
-                                        {
-                                            "label": "Per capita education expenditure",
-                                            "value": "per_capita_expenditure",
-                                        },
-                                        {
-                                            "label": "Total education expenditure",
-                                            "value": "expenditure",
-                                        },
-                                    ],
-                                    value="per_capita_expenditure",
-                                    inline=True,
-                                    style={"padding": "10px"},
-                                    labelStyle={
-                                        "margin-right": "20px",
+                            dbc.RadioItems(
+                                id="education-expenditure-type",
+                                options=[
+                                    {
+                                        "label": "Per capita education expenditure",
+                                        "value": "per_capita_expenditure",
                                     },
-                                ),
-                                style={"flex": "1"},
-                            ),
-                            html.Div(
-                                [
-                                    html.Span(
-                                        "disclaimer",
-                                        id="education-expenditure-warning",
-                                        style={
-                                            "color": "CCCCCC",
-                                            "fontSize": "12px",
-                                            "textDecoration": "underline dotted",
-                                            "cursor": "pointer",
-                                            "fontWeight": "bold",
-                                            "marginLeft": "8px",
-                                        },
-                                    ),
-                                    dbc.Tooltip(
-                                        MAP_DISCLAIMER,
-                                        target="education-expenditure-warning",
-                                        placement="top",
-                                        style={"fontSize": "14px"},
-                                    ),
+                                    {
+                                        "label": "Total education expenditure",
+                                        "value": "expenditure",
+                                    },
                                 ],
-                                style={"display": "flex", "alignItems": "center"},
+                                value="per_capita_expenditure",
+                                inline=True,
+                                style={"padding": "10px"},
+                                labelStyle={
+                                    "margin-right": "20px",
+                                },
                             ),
+                            disclaimer_tooltip("education-expenditure-warning", MAP_DISCLAIMER),
                         ],
                         className="disclaimer-div",
                         style={

--- a/pages/education.py
+++ b/pages/education.py
@@ -5,6 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
+from constants import MAP_DISCLAIMER
 from queries import QueryService
 from utils import (
     empty_plot,
@@ -307,26 +308,61 @@ def render_education_content(tab):
                     )
                 ),
                 dbc.Row(
-                    dbc.Col(
-                        dbc.RadioItems(
-                            id="education-expenditure-type",
-                            options=[
-                                {
-                                    "label": "Per capita education expenditure",
-                                    "value": "per_capita_expenditure",
-                                },
-                                {
-                                    "label": "Total education expenditure",
-                                    "value": "expenditure",
-                                },
-                            ],
-                            value="per_capita_expenditure",
-                            inline=True,
-                            style={"padding": "10px"},
-                            labelStyle={
-                                "margin-right": "20px",
-                            },
-                        ),
+                    html.Div(
+                        [
+                            html.Div(
+                                dbc.RadioItems(
+                                    id="education-expenditure-type",
+                                    options=[
+                                        {
+                                            "label": "Per capita education expenditure",
+                                            "value": "per_capita_expenditure",
+                                        },
+                                        {
+                                            "label": "Total education expenditure",
+                                            "value": "expenditure",
+                                        },
+                                    ],
+                                    value="per_capita_expenditure",
+                                    inline=True,
+                                    style={"padding": "10px"},
+                                    labelStyle={
+                                        "margin-right": "20px",
+                                    },
+                                ),
+                                style={"flex": "1"},
+                            ),
+                            html.Div(
+                                [
+                                    html.Span(
+                                        "disclaimer",
+                                        id="education-expenditure-warning",
+                                        style={
+                                            "color": "CCCCCC",
+                                            "fontSize": "12px",
+                                            "textDecoration": "underline dotted",
+                                            "cursor": "pointer",
+                                            "fontWeight": "bold",
+                                            "marginLeft": "8px",
+                                        },
+                                    ),
+                                    dbc.Tooltip(
+                                        MAP_DISCLAIMER,
+                                        target="education-expenditure-warning",
+                                        placement="top",
+                                        style={"fontSize": "14px"},
+                                    ),
+                                ],
+                                style={"display": "flex", "alignItems": "center"},
+                            ),
+                        ],
+                        className="disclaimer-div",
+                        style={
+                            "display": "flex",
+                            "alignItems": "center",
+                            "justifyContent": "space-between",
+                            "width": "100%",
+                        },
                     ),
                 ),
                 dbc.Row(

--- a/pages/health.py
+++ b/pages/health.py
@@ -25,6 +25,7 @@ from components.edu_health_across_space import (
     update_hd_index_map,
     render_func_subnat_rank,
 )
+from components.disclaimer_div import disclaimer_tooltip
 
 db = QueryService.get_instance()
 
@@ -314,8 +315,8 @@ def render_health_content(tab):
                 ),
                 dbc.Row(
                     dbc.Col(
-                        html.Div([
-                            html.Div(
+                        html.Div(
+                            [
                                 dbc.RadioItems(
                                     id="health-expenditure-type",
                                     options=[
@@ -335,29 +336,16 @@ def render_health_content(tab):
                                         "margin-right": "20px",
                                     },
                                 ),
-                                style={"flex": "1"}
-                            ),
-                            html.Div([
-                                html.Span(
-                                    "disclaimer",
-                                    id="health-expenditure-warning",
-                                    style={
-                                        "color": "CCCCCC",
-                                        "fontSize": "12px",
-                                        "textDecoration": "underline dotted",
-                                        "cursor": "pointer",
-                                        "fontWeight": "bold",
-                                        "marginLeft": "8px",
-                                    },
-                                ),
-                                dbc.Tooltip(
-                                    MAP_DISCLAIMER,
-                                    target="health-expenditure-warning",
-                                    placement="top",
-                                    style={"fontSize": "14px"},
-                                ),
-                            ], style={"display": "flex", "alignItems": "center"}),
-                        ], className="disclaimer-div", style={"display": "flex", "alignItems": "center", "justifyContent": "space-between", "width": "100%"})
+                                disclaimer_tooltip("health-expenditure-warning", MAP_DISCLAIMER),
+                            ],
+                            className="disclaimer-div",
+                            style={
+                                "display": "flex",
+                                "alignItems": "center",
+                                "justifyContent": "space-between",
+                                "width": "100%",
+                            },
+                        ),
                     ),
                 ),
                 dbc.Row(

--- a/pages/health.py
+++ b/pages/health.py
@@ -6,6 +6,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import numpy as np
 import traceback
+from constants import MAP_DISCLAIMER
 from queries import QueryService
 from utils import (
     empty_plot,
@@ -313,25 +314,50 @@ def render_health_content(tab):
                 ),
                 dbc.Row(
                     dbc.Col(
-                        dbc.RadioItems(
-                            id="health-expenditure-type",
-                            options=[
-                                {
-                                    "label": "Per capita health expenditure",
-                                    "value": "per_capita_expenditure",
-                                },
-                                {
-                                    "label": "Total health expenditure",
-                                    "value": "expenditure",
-                                },
-                            ],
-                            value="per_capita_expenditure",
-                            inline=True,
-                            style={"padding": "10px"},
-                            labelStyle={
-                                "margin-right": "20px",
-                            },
-                        ),
+                        html.Div([
+                            html.Div(
+                                dbc.RadioItems(
+                                    id="health-expenditure-type",
+                                    options=[
+                                        {
+                                            "label": "Per capita health expenditure",
+                                            "value": "per_capita_expenditure",
+                                        },
+                                        {
+                                            "label": "Total health expenditure",
+                                            "value": "expenditure",
+                                        },
+                                    ],
+                                    value="per_capita_expenditure",
+                                    inline=True,
+                                    style={"padding": "10px"},
+                                    labelStyle={
+                                        "margin-right": "20px",
+                                    },
+                                ),
+                                style={"flex": "1"}
+                            ),
+                            html.Div([
+                                html.Span(
+                                    "disclaimer",
+                                    id="health-expenditure-warning",
+                                    style={
+                                        "color": "CCCCCC",
+                                        "fontSize": "12px",
+                                        "textDecoration": "underline dotted",
+                                        "cursor": "pointer",
+                                        "fontWeight": "bold",
+                                        "marginLeft": "8px",
+                                    },
+                                ),
+                                dbc.Tooltip(
+                                    MAP_DISCLAIMER,
+                                    target="health-expenditure-warning",
+                                    placement="top",
+                                    style={"fontSize": "14px"},
+                                ),
+                            ], style={"display": "flex", "alignItems": "center"}),
+                        ], className="disclaimer-div", style={"display": "flex", "alignItems": "center", "justifyContent": "space-between", "width": "100%"})
                     ),
                 ),
                 dbc.Row(

--- a/pages/home.py
+++ b/pages/home.py
@@ -15,6 +15,7 @@ from utils import (
 )
 
 from components import slider, get_slider_config, pefa, budget_increment_analysis
+from components.disclaimer_div import disclaimer_tooltip
 from constants import COFOG_CATS, FUNC_COLORS, MAP_DISCLAIMER
 from queries import QueryService
 
@@ -156,23 +157,25 @@ def render_overview_content(tab):
                         dbc.Col(width=4),
                         dbc.Col(
                             [
-                                dbc.RadioItems(
-                                    id="budget-increment-radio",
-                                    options=[
-                                        {
-                                            "label": "Budget",
-                                            "value": "domestic_funded_budget",
-                                        },
-                                        {
-                                            "label": "Inflation-adjusted Budget",
-                                            "value": "real_domestic_funded_budget",
-                                        },
-                                    ],
-                                    value="domestic_funded_budget",
-                                    inline=True,
-                                    style={"padding": "10px"},
-                                    labelStyle={"margin-right": "20px"},
-                                )
+                                html.Div([
+                                    dbc.RadioItems(
+                                        id="budget-increment-radio",
+                                        options=[
+                                            {
+                                                "label": "Budget",
+                                                "value": "domestic_funded_budget",
+                                            },
+                                            {
+                                                "label": "Inflation-adjusted Budget",
+                                                "value": "real_domestic_funded_budget",
+                                            },
+                                        ],
+                                        value="domestic_funded_budget",
+                                        inline=True,
+                                        style={"padding": "10px"},
+                                        labelStyle={"margin-right": "20px"},
+                                    )
+                                ], className='disclaimer-div'),
                             ],
                             width=8,
                         ),
@@ -307,8 +310,8 @@ def render_overview_content(tab):
                 dbc.Row(style={"height": "20px"}),
                 dbc.Row(
                     [
-                        html.Div([
-                            html.Div(
+                        html.Div(
+                            [
                                 dbc.RadioItems(
                                     id="expenditure-plot-radio",
                                     options=[
@@ -328,19 +331,16 @@ def render_overview_content(tab):
                                         "margin-right": "20px",
                                     },
                                 ),
-                                style={"flex": "1"}
-                            ),
-                            html.Div(
-                                [
-                                html.Span('disclaimer', id='warning-sign', style={'color': '"CCCCCC"', 'fontSize': '12px', 'textDecoration': 'underline dotted', 'cursor': 'pointer'}),
-                                dbc.Tooltip(
-                                    MAP_DISCLAIMER,
-                                    target="warning-sign",
-                                    placement="top",
-                                    style={'fontSize': '14px'},
-                                ),
-                            ], style={"display": "flex", "alignItems": "center"}),
-                        ], style={"display": "flex", "alignItems": "center", "justifyContent": "space-between", "width": "100%"}, className='disclaimer-div'),
+                                disclaimer_tooltip("warning-sign", MAP_DISCLAIMER),
+                            ],
+                            className="disclaimer-div",
+                            style={
+                                "display": "flex",
+                                "alignItems": "center",
+                                "justifyContent": "space-between",
+                                "width": "100%",
+                            },
+                        ),
                         # How much was spent in each region?
                         dbc.Col(
                             dcc.Graph(

--- a/pages/home.py
+++ b/pages/home.py
@@ -15,7 +15,7 @@ from utils import (
 )
 
 from components import slider, get_slider_config, pefa, budget_increment_analysis
-from constants import COFOG_CATS, FUNC_COLORS
+from constants import COFOG_CATS, FUNC_COLORS, MAP_DISCLAIMER
 from queries import QueryService
 
 
@@ -307,25 +307,40 @@ def render_overview_content(tab):
                 dbc.Row(style={"height": "20px"}),
                 dbc.Row(
                     [
-                        dbc.RadioItems(
-                            id="expenditure-plot-radio",
-                            options=[
-                                {
-                                    "label": "  Per capita expenditure",
-                                    "value": "percapita",
-                                },
-                                {
-                                    "label": "  Total expenditure",
-                                    "value": "total",
-                                },
-                            ],
-                            value="percapita",
-                            inline=True,
-                            style={"padding": "10px"},
-                            labelStyle={
-                                "margin-right": "20px",
-                            },
-                        ),
+                        html.Div([
+                            html.Div(
+                                dbc.RadioItems(
+                                    id="expenditure-plot-radio",
+                                    options=[
+                                        {
+                                            "label": "  Per capita expenditure",
+                                            "value": "percapita",
+                                        },
+                                        {
+                                            "label": "  Total expenditure",
+                                            "value": "total",
+                                        },
+                                    ],
+                                    value="percapita",
+                                    inline=True,
+                                    style={"padding": "10px"},
+                                    labelStyle={
+                                        "margin-right": "20px",
+                                    },
+                                ),
+                                style={"flex": "1"}
+                            ),
+                            html.Div(
+                                [
+                                html.Span('disclaimer', id='warning-sign', style={'color': '"CCCCCC"', 'fontSize': '12px', 'textDecoration': 'underline dotted', 'cursor': 'pointer'}),
+                                dbc.Tooltip(
+                                    MAP_DISCLAIMER,
+                                    target="warning-sign",
+                                    placement="top",
+                                    style={'fontSize': '14px'},
+                                ),
+                            ], style={"display": "flex", "alignItems": "center"}),
+                        ], style={"display": "flex", "alignItems": "center", "justifyContent": "space-between", "width": "100%"}, className='disclaimer-div'),
                         # How much was spent in each region?
                         dbc.Col(
                             dcc.Graph(
@@ -1239,7 +1254,6 @@ def render_pefa_overall(data, pefa_data, country):
         pefa.pefa_overall_figure(country_pefa_df, country_pov_df),
         pefa.pefa_pillar_heatmap(country_pefa_df),
     )
-
 
 
 @callback(


### PR DESCRIPTION
Add disclaimer for map visualizations as a tooltip.The changes are applied for all map viz under home, health and edu tabs.

`"Country borders or names do not necessarily reflect the World Bank Group's official position." \
"This map is for illustrative purposes and does not imply the expression of any opinion on the part of the World Bank," \
"concerning the legal status of any country or territory or concerning the delimitation of frontiers or boundaries."`

<img width="1464" alt="Screenshot 2025-07-02 at 5 15 07 PM" src="https://github.com/user-attachments/assets/2d861b87-62d1-4e85-a431-1021524bd3f8" />
