### PR TITLE
Rename government_budget→government_revenue_expenditure

### DIFF
--- a/components/fiscal_balance.py
+++ b/components/fiscal_balance.py
@@ -37,7 +37,7 @@ DEFICIT_BAR_OPACITY = 0.4
 
 
 def split_imf_sources(gov_df):
-    """Split an IMF government-budget frame into ``(gfs_df, weo_df)`` by data source."""
+    """Split an IMF government revenue/expenditure frame into ``(gfs_df, weo_df)`` by data source."""
     if gov_df is None or gov_df.empty:
         return None, None
     return (

--- a/constants.py
+++ b/constants.py
@@ -9,7 +9,7 @@ TREND_THRESHOLDS = 0.4
 
 WEO_SOURCE = "WEO (World Economic Outlook), IMF — General Government"
 GFS_SOO_SOURCE = "GFS_SOO (Statement of Operations), IMF — Budgetary Central Government"
-IMF_GOVERNMENT_BUDGET_SOURCES = [WEO_SOURCE, GFS_SOO_SOURCE]
+IMF_GOVERNMENT_REVENUE_EXPENDITURE_SOURCES = [WEO_SOURCE, GFS_SOO_SOURCE]
 
 # Fiscal-balance view modes — shared by the deficit chart component
 # (components/fiscal_balance.py) and the home page's view selector.

--- a/data_mapping.py
+++ b/data_mapping.py
@@ -207,7 +207,7 @@ function_data_mapping = {
     "hd_index": lambda: _db().get_hd_index(_countries()),
     "edu_private_expenditure": lambda: _db().get_edu_private_expenditure(),
     "togo_revenue_budget": lambda: _db().get_togo_revenue_budget_data(),
-    "government_budget": lambda: _db().get_government_budget_data(),
+    "government_revenue_expenditure": lambda: _db().get_government_revenue_expenditure_data(),
     # Transformation loaders
     "func_econ_raw": load_func_econ_raw,
     "func_by_country_year": load_func_by_country_year,

--- a/pages/home.py
+++ b/pages/home.py
@@ -70,7 +70,7 @@ def layout():
             ),
             dcc.Store(id="stored-data-pefa"),
             dcc.Store(id="stored-data-revenue-budget"),
-            dcc.Store(id="stored-data-government-budget"),
+            dcc.Store(id="stored-data-government-revenue-expenditure"),
         ]
     )
 
@@ -109,13 +109,13 @@ def fetch_revenue_budget_data_once(revenue_data, shared_data):
     return dash.no_update
 
 @callback(
-    Output("stored-data-government-budget", "data"),
-    Input("stored-data-government-budget", "data"),
+    Output("stored-data-government-revenue-expenditure", "data"),
+    Input("stored-data-government-revenue-expenditure", "data"),
     Input("stored-data", "data"),
 )
-def fetch_government_budget_data_once(gov_data, shared_data):
+def fetch_government_revenue_expenditure_data_once(gov_data, shared_data):
     if gov_data is None and shared_data:
-        server_store.get("government_budget")
+        server_store.get("government_revenue_expenditure")
         return {"ready": True}
     return dash.no_update
 
@@ -1436,7 +1436,7 @@ def render_budget_func_changes(data, country, exp_type, lang):
 def _get_revenue_budget_context(country):
     """Load country-scoped fiscal-balance inputs from server store."""
     national_df = filter_country_sort_year(server_store.get("togo_revenue_budget"), country)
-    gov_df = filter_country_sort_year(server_store.get("government_budget"), country)
+    gov_df = filter_country_sort_year(server_store.get("government_revenue_expenditure"), country)
     gfs_df, weo_df = fiscal_balance.split_imf_sources(gov_df)
     basic_info = server_store.get("basic_country_info")[country]
     return national_df, gfs_df, weo_df, basic_info
@@ -1487,7 +1487,7 @@ def update_revenue_expenditure_view_options(country, lang, revenue_data, current
 @callback(
     Output("revenue-expenditure-combined", "figure"),
     Input("stored-data-revenue-budget", "data"),
-    Input("stored-data-government-budget", "data"),
+    Input("stored-data-government-revenue-expenditure", "data"),
     Input("country-select", "value"),
     Input("stored-basic-country-data", "data"),
     Input("revenue-expenditure-view", "value"),
@@ -1514,7 +1514,7 @@ def render_revenue_expenditure_combined(revenue_data, gov_data, country, country
 @callback(
     Output("revenue-expenditure-narrative", "children"),
     Input("stored-data-revenue-budget", "data"),
-    Input("stored-data-government-budget", "data"),
+    Input("stored-data-government-revenue-expenditure", "data"),
     Input("country-select", "value"),
     Input("stored-basic-country-data", "data"),
     Input("revenue-expenditure-view", "value"),

--- a/queries.py
+++ b/queries.py
@@ -6,7 +6,7 @@ from databricks import sql
 from databricks.sdk.core import Config, oauth_service_principal
 from databricks.sdk import WorkspaceClient
 
-from constants import IMF_GOVERNMENT_BUDGET_SOURCES
+from constants import IMF_GOVERNMENT_REVENUE_EXPENDITURE_SOURCES
 from query_cache import PersistentQueryCache
 
 
@@ -246,9 +246,9 @@ class QueryService:
         """
         return self.fetch_data(query)
 
-    def get_government_budget_data(self):
+    def get_government_revenue_expenditure_data(self):
         source_filter = ",\n                ".join(
-            f"'{src}'" for src in IMF_GOVERNMENT_BUDGET_SOURCES
+            f"'{src}'" for src in IMF_GOVERNMENT_REVENUE_EXPENDITURE_SOURCES
         )
         query = f"""
             SELECT
@@ -259,7 +259,7 @@ class QueryService:
                 expenditure_current_lcu AS expenditure,
                 data_source AS source,
                 is_forecast
-            FROM prd_mega.{INDICATOR_SCHEMA}.government_budget
+            FROM prd_mega.{INDICATOR_SCHEMA}.government_revenue_expenditure
             WHERE data_source IN (
                 {source_filter}
             )


### PR DESCRIPTION
## What
Repoint the dashboard from the renamed pipeline table and rename the matching internal identifiers:
- Table: `prd_mega.indicator.government_budget` → `government_revenue_expenditure` (`queries.py`)
- `get_government_budget_data` → `get_government_revenue_expenditure_data`
- `IMF_GOVERNMENT_BUDGET_SOURCES` → `IMF_GOVERNMENT_REVENUE_EXPENDITURE_SOURCES`
- server_store key `"government_budget"` → `"government_revenue_expenditure"`
- callback `fetch_government_budget_data_once` → `fetch_government_revenue_expenditure_data_once`
- Dash Store id `stored-data-government-budget` → `stored-data-government-revenue-expenditure`
- docstring wording in `components/fiscal_balance.py`

## Why
Mirrors the pipeline rename in **mega-indicators** (`government_budget.py` → `government_revenue_expenditure.py`). The table holds government revenue/expenditure flows, not a "budget".

## Coordination
- ⚠️ Depends on **dime-worldbank/mega-indicators#35** — the renamed table must exist in `prd_mega.indicator` before this deploys, or the dashboard query breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)